### PR TITLE
Only warn if the .env file can not be loaded

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	var c Config
 	err := godotenv.Load(".env")
 	if err != nil {
-		logrus.Fatal("failed to get env value")
+		logrus.Warn("Failed to load .env file")
 	}
 
 	err = envconfig.Process("", &c)


### PR DESCRIPTION
.env files should be optional in a production environment it is likely that the env variables are set explicitely and not through a file