### PR TITLE
Do not return invoices that are in the initialized state

### DIFF
--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -74,7 +74,7 @@ func (svc *LndhubService) InvoicesFor(ctx context.Context, userId int64, invoice
 
 	query := svc.DB.NewSelect().Model(&invoices).Where("user_id = ?", userId)
 	if invoiceType != "" {
-		query.Where("type = ?", invoiceType)
+		query.Where("type = ? AND state <> ?", invoiceType, "initialized")
 	}
 	query.OrderExpr("id DESC").Limit(100)
 	err := query.Scan(ctx)


### PR DESCRIPTION
Initialized is an internal state before the invoice was created on LND.
We should not expose those. If an invoice is in that state it means it is either currently created or something went wrong.