### PR TITLE
add CD steps to build workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - main
-    tags:        
-      - '*'
+  release:
+    types: [published]
 jobs:
   build:
     env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -38,7 +38,7 @@ jobs:
         repository: getalby/alby-deployment
         branch: main
         createPR: false
-        message: 'CD: Update lndhub tag to ${{ steps.build.outputs.tag }}'
+        message: 'CD: Update lndhub tag to ${{ steps.build.outputs.tags }}'
         token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         workDir: infrastructure
     # Only update prod environment if this action was triggered by a new tag

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,3 +21,36 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Checkout deployment repo
+      uses: actions/checkout@v2
+      with:
+        repository: getalby/alby-deployment
+        path: infrastructure
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    # Always update dev environment 
+    - name: Update dev environment
+      uses: fjogeleit/yaml-update-action@v0.7.0
+      with:
+        valueFile: alby-simnet-deployment/values.yaml'
+        propertyPath: 'lndhub.image.tag'
+        value: ${{ steps.build.outputs.tags }}
+        repository: getalby/alby-deployment
+        branch: main
+        createPR: false
+        message: 'CD: Update lndhub tag to ${{ steps.build.outputs.tag }}'
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        workDir: infrastructure
+    # Only update prod environment if this action was triggered by a new tag
+    - name: Update production environment
+      if: startsWith(github.ref, 'refs/tags')
+      uses: fjogeleit/yaml-update-action@v0.7.0
+      with:
+        valueFile: alby-mainnet-deployment/values.yaml'
+        propertyPath: 'lndhub.image.tag'
+        value: ${{ steps.build.outputs.tags }}
+        repository: getalby/alby-deployment
+        branch: main
+        createPR: false
+        message: 'CD: Update lndhub tag to ${{ steps.build.outputs.tag }}'
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        workDir: infrastructure

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -26,7 +26,7 @@ jobs:
       with:
         repository: getalby/alby-deployment
         path: infrastructure
-        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
     # Always update dev environment 
     - name: Update dev environment
       uses: fjogeleit/yaml-update-action@v0.7.0
@@ -38,7 +38,7 @@ jobs:
         branch: main
         createPR: false
         message: 'CD: Update lndhub tag to ${{ steps.build.outputs.tag }}'
-        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         workDir: infrastructure
     # Only update prod environment if this action was triggered by a new tag
     - name: Update production environment

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -26,7 +26,7 @@ jobs:
       with:
         repository: getalby/alby-deployment
         path: infrastructure
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     # Always update dev environment 
     - name: Update dev environment
       uses: fjogeleit/yaml-update-action@v0.7.0
@@ -38,7 +38,7 @@ jobs:
         branch: main
         createPR: false
         message: 'CD: Update lndhub tag to ${{ steps.build.outputs.tag }}'
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         workDir: infrastructure
     # Only update prod environment if this action was triggered by a new tag
     - name: Update production environment

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,6 +16,7 @@ jobs:
       name: Check out code
     - name: Docker build
       uses: mr-smithers-excellent/docker-build-push@v5
+      id: build
       with:
         image: ${{ env.IMAGENAME }}
         registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
Deploys all pushes to master to the dev environment, only deploys tagged versions of master to production environment.