### PR TITLE
Avoid using mysql-specific syntax for timestamp

### DIFF
--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -20,7 +20,8 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 	svc.Logger.Infof("Invoice update: r_hash:%s state:%v", rHashStr, rawInvoice.State.String())
 
 	// Search for an incoming invoice with the r_hash that is NOT settled in our DB
-	err := svc.DB.NewSelect().Model(&invoice).Where("type = ? AND r_hash = ? AND state <> ? AND expires_at > NOW()", "incoming", rHashStr, "settled").Limit(1).Scan(ctx)
+	now := time.Now()
+	err := svc.DB.NewSelect().Model(&invoice).Where("type = ? AND r_hash = ? AND state <> ? AND expires_at > ?", "incoming", rHashStr, "settled", now).Limit(1).Scan(ctx)
 	if err != nil {
 		svc.Logger.Infof("Invoice not found. Ignoring. r_hash:%s", rHashStr)
 		return nil


### PR DESCRIPTION
Paid invoices won't be picked up when using SQLite without this fix. 