### PR TITLE
Feature/wrap-lnd

### DIFF
--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/getAlby/lndhub.go/db/models"
+	"github.com/getAlby/lndhub.go/lnd"
 	"github.com/getsentry/sentry-go"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/uptrace/bun"
@@ -95,7 +96,7 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 	return nil
 }
 
-func (svc *LndhubService) ConnectInvoiceSubscription(ctx context.Context) (lnrpc.Lightning_SubscribeInvoicesClient, error) {
+func (svc *LndhubService) ConnectInvoiceSubscription(ctx context.Context) (lnd.SubscribeInvoicesWrapper, error) {
 	var invoice models.Invoice
 	invoiceSubscriptionOptions := lnrpc.InvoiceSubscription{}
 	// Find the oldest NOT settled invoice with an add_index

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -8,8 +8,8 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/getAlby/lndhub.go/db/models"
 	"github.com/getAlby/lndhub.go/lib/tokens"
+	"github.com/getAlby/lndhub.go/lnd"
 	"github.com/labstack/gommon/random"
-	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/uptrace/bun"
 	"github.com/ziflex/lecho/v3"
 	"golang.org/x/crypto/bcrypt"
@@ -20,7 +20,7 @@ const alphaNumBytes = random.Alphanumeric
 type LndhubService struct {
 	Config         *Config
 	DB             *bun.DB
-	LndClient      lnrpc.LightningClient
+	LndClient      lnd.LightningClientWrapper
 	Logger         *lecho.Logger
 	IdentityPubkey *btcec.PublicKey
 }

--- a/lnd/interface.go
+++ b/lnd/interface.go
@@ -1,0 +1,20 @@
+package lnd
+
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"google.golang.org/grpc"
+)
+
+type LightningClientWrapper interface {
+	ListChannels(ctx context.Context, req *lnrpc.ListChannelsRequest, options ...grpc.CallOption) (*lnrpc.ListChannelsResponse, error)
+	SendPaymentSync(ctx context.Context, req *lnrpc.SendRequest, options ...grpc.CallOption) (*lnrpc.SendResponse, error)
+	AddInvoice(ctx context.Context, req *lnrpc.Invoice, options ...grpc.CallOption) (*lnrpc.AddInvoiceResponse, error)
+	SubscribeInvoices(ctx context.Context, req *lnrpc.InvoiceSubscription, options ...grpc.CallOption) (SubscribeInvoicesWrapper, error)
+	GetInfo(ctx context.Context, req *lnrpc.GetInfoRequest, options ...grpc.CallOption) (*lnrpc.GetInfoResponse, error)
+}
+
+type SubscribeInvoicesWrapper interface {
+	Recv() (*lnrpc.Invoice, error)
+}


### PR DESCRIPTION
Wrapping the Lightning Client allows us to plug in different Lightning back-ends.
I've opted to keep using the data structures defined by the lnrpc package.
I've also needed to wrap the Subscriber, because other subscriptions don't need an entire grpc subscriber.