### PR TITLE
Remove context todo

### DIFF
--- a/controllers/addinvoice.ctrl.go
+++ b/controllers/addinvoice.ctrl.go
@@ -45,7 +45,7 @@ func (controller *AddInvoiceController) AddInvoice(c echo.Context) error {
 	}
 	c.Logger().Infof("Adding invoice: user_id=%v memo=%s value=%v description_hash=%s", userID, body.Memo, amount, body.DescriptionHash)
 
-	invoice, err := controller.svc.AddIncomingInvoice(userID, amount, body.Memo, body.DescriptionHash)
+	invoice, err := controller.svc.AddIncomingInvoice(c.Request().Context(), userID, amount, body.Memo, body.DescriptionHash)
 	if err != nil {
 		c.Logger().Errorf("Error creating invoice: %v", err)
 		sentry.CaptureException(err)

--- a/controllers/auth.ctrl.go
+++ b/controllers/auth.ctrl.go
@@ -41,7 +41,7 @@ func (controller *AuthController) Auth(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
 
-	accessToken, refreshToken, err := controller.svc.GenerateToken(body.Login, body.Password, body.RefreshToken)
+	accessToken, refreshToken, err := controller.svc.GenerateToken(c.Request().Context(), body.Login, body.Password, body.RefreshToken)
 	if err != nil {
 		return err
 	}

--- a/controllers/balance.ctrl.go
+++ b/controllers/balance.ctrl.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/getAlby/lndhub.go/lib/service"
@@ -20,7 +19,7 @@ func NewBalanceController(svc *service.LndhubService) *BalanceController {
 // Balance : Balance Controller
 func (controller *BalanceController) Balance(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
-	balance, err := controller.svc.CurrentUserBalance(context.TODO(), userId)
+	balance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userId)
 	if err != nil {
 		return err
 	}

--- a/controllers/checkpayment.ctrl.go
+++ b/controllers/checkpayment.ctrl.go
@@ -22,7 +22,7 @@ func (controller *CheckPaymentController) CheckPayment(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 	rHash := c.Param("payment_hash")
 
-	invoice, err := controller.svc.FindInvoiceByPaymentHash(userId, rHash)
+	invoice, err := controller.svc.FindInvoiceByPaymentHash(c.Request().Context(), userId, rHash)
 
 	// Probably we did not find the invoice
 	if err != nil {

--- a/controllers/create.ctrl.go
+++ b/controllers/create.ctrl.go
@@ -33,7 +33,7 @@ func (controller *CreateUserController) CreateUser(c echo.Context) error {
 	if err := c.Bind(&body); err != nil {
 		return err
 	}
-	user, err := controller.svc.CreateUser()
+	user, err := controller.svc.CreateUser(c.Request().Context())
 	//todo json response
 	if err != nil {
 		return err

--- a/controllers/getinfo.ctrl.go
+++ b/controllers/getinfo.ctrl.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/getAlby/lndhub.go/lib/service"
@@ -21,7 +20,7 @@ func NewGetInfoController(svc *service.LndhubService) *GetInfoController {
 func (controller *GetInfoController) GetInfo(c echo.Context) error {
 
 	// TODO: add some caching for this GetInfo call. No need to always hit the node
-	info, err := controller.svc.GetInfo(context.TODO())
+	info, err := controller.svc.GetInfo(c.Request().Context())
 	if err != nil {
 		return err
 	}

--- a/controllers/gettxs.ctrl.go
+++ b/controllers/gettxs.ctrl.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/getAlby/lndhub.go/lib"
@@ -22,7 +21,7 @@ func NewGetTXSController(svc *service.LndhubService) *GetTXSController {
 func (controller *GetTXSController) GetTXS(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 
-	invoices, err := controller.svc.InvoicesFor(context.TODO(), userId, "outgoing")
+	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, "outgoing")
 	if err != nil {
 		return err
 	}
@@ -47,7 +46,7 @@ func (controller *GetTXSController) GetTXS(c echo.Context) error {
 func (controller *GetTXSController) GetUserInvoices(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 
-	invoices, err := controller.svc.InvoicesFor(context.TODO(), userId, "incoming")
+	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, "incoming")
 	if err != nil {
 		return err
 	}

--- a/controllers/home.ctrl.go
+++ b/controllers/home.ctrl.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"bytes"
-	"context"
 	_ "embed"
 	"fmt"
 	"html/template"
@@ -72,11 +71,11 @@ func (controller *HomeController) QR(c echo.Context) error {
 }
 
 func (controller *HomeController) Home(c echo.Context) error {
-	info, err := controller.svc.GetInfo(context.TODO())
+	info, err := controller.svc.GetInfo(c.Request().Context())
 	if err != nil {
 		return err
 	}
-	channels, err := controller.svc.LndClient.ListChannels(context.TODO(), &lnrpc.ListChannelsRequest{})
+	channels, err := controller.svc.LndClient.ListChannels(c.Request().Context(), &lnrpc.ListChannelsRequest{})
 	if err != nil {
 		return err
 	}

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -58,12 +57,12 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		}
 	*/
 
-	invoice, err := controller.svc.AddOutgoingInvoice(userID, paymentRequest, decodedPaymentRequest)
+	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, paymentRequest, decodedPaymentRequest)
 	if err != nil {
 		return err
 	}
 
-	currentBalance, err := controller.svc.CurrentUserBalance(context.TODO(), userID)
+	currentBalance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userID)
 	if err != nil {
 		return err
 	}
@@ -74,7 +73,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
 	}
 
-	sendPaymentResponse, err := controller.svc.PayInvoice(invoice)
+	sendPaymentResponse, err := controller.svc.PayInvoice(c.Request().Context(), invoice)
 	if err != nil {
 		c.Logger().Errorf("Payment failed: %v", err)
 		sentry.CaptureException(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -25,13 +25,13 @@ type LndhubService struct {
 	IdentityPubkey *btcec.PublicKey
 }
 
-func (svc *LndhubService) GenerateToken(login, password, inRefreshToken string) (accessToken, refreshToken string, err error) {
+func (svc *LndhubService) GenerateToken(ctx context.Context, login, password, inRefreshToken string) (accessToken, refreshToken string, err error) {
 	var user models.User
 
 	switch {
 	case login != "" || password != "":
 		{
-			if err := svc.DB.NewSelect().Model(&user).Where("login = ?", login).Scan(context.TODO()); err != nil {
+			if err := svc.DB.NewSelect().Model(&user).Where("login = ?", login).Scan(ctx); err != nil {
 				return "", "", fmt.Errorf("bad auth")
 			}
 			if bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)) != nil {

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -10,7 +10,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func (svc *LndhubService) CreateUser() (user *models.User, err error) {
+func (svc *LndhubService) CreateUser(ctx context.Context) (user *models.User, err error) {
 
 	user = &models.User{}
 
@@ -24,7 +24,7 @@ func (svc *LndhubService) CreateUser() (user *models.User, err error) {
 	// Create user and the user's accounts
 	// We use double-entry bookkeeping so we use 4 accounts: incoming, current, outgoing and fees
 	// Wrapping this in a transaction in case something fails
-	err = svc.DB.RunInTx(context.TODO(), &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+	err = svc.DB.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
 		if _, err := tx.NewInsert().Model(user).Exec(ctx); err != nil {
 			return err
 		}
@@ -59,7 +59,7 @@ func (svc *LndhubService) CurrentUserBalance(ctx context.Context, userId int64) 
 	if err != nil {
 		return balance, err
 	}
-	err = svc.DB.NewSelect().Table("account_ledgers").ColumnExpr("sum(account_ledgers.amount) as balance").Where("account_ledgers.account_id = ?", account.ID).Scan(context.TODO(), &balance)
+	err = svc.DB.NewSelect().Table("account_ledgers").ColumnExpr("sum(account_ledgers.amount) as balance").Where("account_ledgers.account_id = ?", account.ID).Scan(ctx, &balance)
 	return balance, err
 }
 


### PR DESCRIPTION
Reference issue: https://github.com/getAlby/lndhub.go/issues/55

There are 2 methods for creating contexts, context.Background() and context.TODO(). They both return empty context, only difference is in name: TODO should be used on places where we are not sure about if we need context, or context behavior.
However, it seems that repo currently passes context to external package db methods, and I assume that is because this context can be used to timeout or cancel db operations. Using TODO doesn't make much sense here since we are just passing context to these methods, but we know the usage, so we should pass in parent context.

According to this https://www.ardanlabs.com/blog/2019/09/context-package-semantics-in-go.html
Incoming requests to a server should create a Context, but because http.Request already has context we can use that one as a top level, which defaults to empty context.Background.
I did this in 2 steps:
- located context.TODO in service methods and replaced it with ctx passed in as first argument (added ctx as first argument on places where it was not there already)
- pass in request context to service methods from controller handlers

Before changes, I noticed some of services methods already had ctx as first argument, some did not. Some service methods used ctx passed in to method, but some created TODO, some used combination. This PR also makes using context a bit more uniform across the app.