### PR TITLE
add build workflow

### DIFF
--- a/.github/workflows/build_binaries.yaml
+++ b/.github/workflows/build_binaries.yaml
@@ -1,8 +1,8 @@
 name: Build and publish binaries
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types:
+      - created
 jobs:
   build:
     name: Build and publish binaries
@@ -12,6 +12,10 @@ jobs:
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
     - name: Check out code
       uses: actions/checkout@v2
     - name: Build Binary for linux

--- a/.github/workflows/build_binaries.yaml
+++ b/.github/workflows/build_binaries.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
     - name: Check out code

--- a/.github/workflows/build_binaries.yaml
+++ b/.github/workflows/build_binaries.yaml
@@ -18,9 +18,11 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Check out code
       uses: actions/checkout@v2
-    - name: Build Binary for linux
+    - name: Build Binary for linux amd64
       run: go build -o lndhub-${{github.event.release.tag_name}}-linux-x86_64
-    - name: Upload to release assets
+    - name: Build Binary for linux arm v7
+      run: GOOS=linux GOARCH=arm GOARM=7 go build -o lndhub-${{github.event.release.tag_name}}-linux-arm_v7
+    - name: Upload amd64 binary to release assets
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,4 +30,13 @@ jobs:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ./lndhub-${{github.event.release.tag_name}}-linux-x86_64
         asset_name: lndhub-${{github.event.release.tag_name}}-linux-x86_64
+        asset_content_type: binary/octet-stream
+    - name: Upload armv7 binary to release assets
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./lndhub-${{github.event.release.tag_name}}-linux-arm_v7
+        asset_name: lndhub-${{github.event.release.tag_name}}-linux-arm_v7
         asset_content_type: binary/octet-stream

--- a/.github/workflows/build_binaries.yaml
+++ b/.github/workflows/build_binaries.yaml
@@ -19,13 +19,13 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     - name: Build Binary for linux
-      run: go build -o lndhub-${{github.event.release.tag_name}}linux-x86_64
+      run: go build -o lndhub-${{github.event.release.tag_name}}-linux-x86_64
     - name: Upload to release assets
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./lndhub-${{github.event.release.tag_name}}linux-x86_64
-        asset_name: lndhub-${{github.event.release.tag_name}}linux-x86_64
+        asset_path: ./lndhub-${{github.event.release.tag_name}}-linux-x86_64
+        asset_name: lndhub-${{github.event.release.tag_name}}-linux-x86_64
         asset_content_type: binary/octet-stream

--- a/.github/workflows/build_binaries.yaml
+++ b/.github/workflows/build_binaries.yaml
@@ -1,0 +1,27 @@
+name: Build and publish binaries
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    name: Build and publish binaries
+    strategy:
+      matrix:
+        go-version: [ 1.16.x ]
+        platform: [ ubuntu-latest ]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Build Binary for linux
+      run: go build -o lndhub-${{github.event.release.tag_name}}linux-x86_64
+    - name: Upload to release assets
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./lndhub-${{github.event.release.tag_name}}linux-x86_64
+        asset_name: lndhub-${{github.event.release.tag_name}}linux-x86_64
+        asset_content_type: binary/octet-stream


### PR DESCRIPTION
In practice, lndhub will always run on a linux server, so there is no need for any other binaries.