### PR TITLE
Sensitive data from sentry payload

### DIFF
--- a/controllers/auth.ctrl.go
+++ b/controllers/auth.ctrl.go
@@ -35,7 +35,8 @@ func (controller *AuthController) Auth(c echo.Context) error {
 	var body AuthRequestBody
 
 	if err := c.Bind(&body); err != nil {
-		return err
+		c.Logger().Errorf("Failed to load auth user request body: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
 	if err := c.Validate(&body); err != nil {
 		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)

--- a/controllers/create.ctrl.go
+++ b/controllers/create.ctrl.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"net/http"
 
+	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/service"
 	"github.com/labstack/echo/v4"
 )
@@ -33,12 +34,13 @@ func (controller *CreateUserController) CreateUser(c echo.Context) error {
 	var body CreateUserRequestBody
 
 	if err := c.Bind(&body); err != nil {
-		return err
+		c.Logger().Errorf("Failed to load create user request body: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
 	user, err := controller.svc.CreateUser(c.Request().Context(), body.Login, body.Password)
-	//todo json response
 	if err != nil {
-		return err
+		c.Logger().Errorf("Failed to create user: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
 
 	var ResponseBody CreateUserResponseBody


### PR DESCRIPTION
This PR is more for discussion, please read this summary:

It looks like sentry is capturing exceptions in 2 ways, either in generic http response handler, or manually calling CaptureException method. Issue is mentioning one example of sensitive data captured, refresh and access token, and that should be fixed with this commit https://github.com/getAlby/lndhub.go/pull/116/commits/f615564728909b241e322d5151ddd14d3f99ba68.
Below is summary of other places where this can occur, I don't think there is more sensitive data, apart from UserID comment:
```
did we change something that this userId is no longer sent to sentry:
https://github.com/getAlby/lndhub.go/blob/main/lib/responses/errors.go#L46-L50
```
^ does this mean that there is a bug with userId not being sent or?

1. controllers returning error instead of concrete response
- create ctrl
i changed this one because there was todo, but might be better to return err on line 41, because it might not fail due to bad request only

- balance, get txs
only sql errors, i don't think there is sensitive info (eg sql not found)

- get info
probably no sensitive data, since error coming from lndClient.GetInfo method

- pay invoice
sql errors
add outgoing invoice errors

2. manually calling CaptureException method
Sometimes this happens when controller returns response, but only on couple of places, should we do it for all?
eg. 

- addinvoice
when addIncomingInvoice fails, which can be due to sql error 
decode description hash string
lndClient.AddInvoice

- payinvoice
decode payment request (LndClient.DecodeBolt11)

- payInvoice
sql errors
lndClient.SendPaymentSync

q: should we standardize error handling, at least at controller level, for example it should always log error, it should return proper response and capture exception etc, because it seems there are couple different ways in current code?
