### PR TITLE
Feature/keysend-custom-records

### DIFF
--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/getAlby/lndhub.go/lib"
 	"github.com/getAlby/lndhub.go/lib/responses"
@@ -23,9 +24,10 @@ func NewKeySendController(svc *service.LndhubService) *KeySendController {
 }
 
 type KeySendRequestBody struct {
-	Amount      int64  `json:"amount" validate:"required"`
-	Destination string `json:"destination" validate:"required"`
-	Memo        string `json:"memo" validate:"omitempty"`
+	Amount        int64             `json:"amount" validate:"required"`
+	Destination   string            `json:"destination" validate:"required"`
+	Memo          string            `json:"memo" validate:"omitempty"`
+	CustomRecords map[string]string `json:"customRecords" validate:"omitempty"`
 }
 
 type KeySendResponseBody struct {
@@ -77,6 +79,14 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
 	}
 
+	invoice.DestinationCustomRecords = map[uint64][]byte{}
+	for key, value := range reqBody.CustomRecords {
+		intKey, err := strconv.Atoi(key)
+		if err != nil {
+			return err
+		}
+		invoice.DestinationCustomRecords[uint64(intKey)] = []byte(value)
+	}
 	sendPaymentResponse, err := controller.svc.PayInvoice(c.Request().Context(), invoice)
 	if err != nil {
 		c.Logger().Errorf("Payment failed: %v", err)

--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -83,7 +83,7 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 	for key, value := range reqBody.CustomRecords {
 		intKey, err := strconv.Atoi(key)
 		if err != nil {
-			return err
+			return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 		}
 		invoice.DestinationCustomRecords[uint64(intKey)] = []byte(value)
 	}

--- a/db/models/invoice.go
+++ b/db/models/invoice.go
@@ -9,27 +9,28 @@ import (
 
 // Invoice : Invoice Model
 type Invoice struct {
-	ID                   int64        `json:"id" bun:",pk,autoincrement"`
-	Type                 string       `json:"type" validate:"required"`
-	UserID               int64        `json:"user_id" validate:"required"`
-	User                 *User        `bun:"rel:belongs-to,join:user_id=id"`
-	Amount               int64        `json:"amount" validate:"gte=0"`
-	Fee                  int64        `json:"fee" bun:",nullzero"`
-	Memo                 string       `json:"memo" bun:",nullzero"`
-	DescriptionHash      string       `json:"description_hash" bun:",nullzero"`
-	PaymentRequest       string       `json:"payment_request" bun:",nullzero"`
-	DestinationPubkeyHex string       `json:"destination_pubkey_hex" bun:",notnull"`
-	RHash                string       `json:"r_hash"`
-	Preimage             string       `json:"preimage" bun:",nullzero"`
-	Internal             bool         `json:"internal" bun:",nullzero"`
-	Keysend              bool         `json:"keysend" bun:",nullzero"`
-	State                string       `json:"state" bun:",default:'initialized'"`
-	ErrorMessage         string       `json:"error_message" bun:",nullzero"`
-	AddIndex             uint64       `json:"add_index" bun:",nullzero"`
-	CreatedAt            time.Time    `bun:",nullzero,notnull,default:current_timestamp"`
-	ExpiresAt            bun.NullTime `bun:",nullzero"`
-	UpdatedAt            bun.NullTime `json:"updated_at"`
-	SettledAt            bun.NullTime `json:"settled_at"`
+	ID                       int64             `json:"id" bun:",pk,autoincrement"`
+	Type                     string            `json:"type" validate:"required"`
+	UserID                   int64             `json:"user_id" validate:"required"`
+	User                     *User             `bun:"rel:belongs-to,join:user_id=id"`
+	Amount                   int64             `json:"amount" validate:"gte=0"`
+	Fee                      int64             `json:"fee" bun:",nullzero"`
+	Memo                     string            `json:"memo" bun:",nullzero"`
+	DescriptionHash          string            `json:"description_hash" bun:",nullzero"`
+	PaymentRequest           string            `json:"payment_request" bun:",nullzero"`
+	DestinationPubkeyHex     string            `json:"destination_pubkey_hex" bun:",notnull"`
+	DestinationCustomRecords map[uint64][]byte `bun:"-"`
+	RHash                    string            `json:"r_hash"`
+	Preimage                 string            `json:"preimage" bun:",nullzero"`
+	Internal                 bool              `json:"internal" bun:",nullzero"`
+	Keysend                  bool              `json:"keysend" bun:",nullzero"`
+	State                    string            `json:"state" bun:",default:'initialized'"`
+	ErrorMessage             string            `json:"error_message" bun:",nullzero"`
+	AddIndex                 uint64            `json:"add_index" bun:",nullzero"`
+	CreatedAt                time.Time         `bun:",nullzero,notnull,default:current_timestamp"`
+	ExpiresAt                bun.NullTime      `bun:",nullzero"`
+	UpdatedAt                bun.NullTime      `json:"updated_at"`
+	SettledAt                bun.NullTime      `json:"settled_at"`
 }
 
 func (i *Invoice) BeforeAppendModel(ctx context.Context, query bun.Query) error {

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -164,6 +164,8 @@ func (suite *TestSuite) createKeySendReq(amount int64, memo, destination, token 
 		Amount:      amount,
 		Destination: destination,
 		Memo:        memo,
+		//add memo as WHATSAT_MESSAGE custom record
+		CustomRecords: map[string]string{fmt.Sprint(service.TLV_WHATSAT_MESSAGE): memo},
 	}))
 	req := httptest.NewRequest(http.MethodPost, "/keysend", &buf)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -157,13 +157,14 @@ func createLnRpcSendRequest(invoice *models.Invoice) (*lnrpc.SendRequest, error)
 	if err != nil {
 		return nil, err
 	}
+	invoice.DestinationCustomRecords[KEYSEND_CUSTOM_RECORD] = preImage
 	return &lnrpc.SendRequest{
 		Dest:              destBytes,
 		Amt:               invoice.Amount,
 		PaymentHash:       pHash.Sum(nil),
 		FeeLimit:          &feeLimit,
 		DestFeatures:      []lnrpc.FeatureBit{lnrpc.FeatureBit_TLV_ONION_REQ},
-		DestCustomRecords: map[uint64][]byte{KEYSEND_CUSTOM_RECORD: preImage, TLV_WHATSAT_MESSAGE: []byte(invoice.Memo)},
+		DestCustomRecords: invoice.DestinationCustomRecords,
 	}, nil
 }
 


### PR DESCRIPTION
Allow custom TLV records to be passed on.

The memo field is now internal. If you want to send a Whatsat message, you should specify the TLV record explicitly in th request:

```
http POST http://$host/keysend destination=025c1d5d1b4c983cc6350fc2d756fbb59b4dc365e45e87f8e3afe07e24013e8220 amount:=101 customRecords:='{"34349334":"test_whatsatee"}' Authorization:"Bearer $token"
```