### PR TITLE
Fix/pay-response

### DIFF
--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -38,7 +38,7 @@ type KeySendResponseBody struct {
 	DescriptionHashStr string                `json:"description_hash,omitempty"`
 	PaymentError       string                `json:"payment_error,omitempty"`
 	PaymentPreimage    *lib.JavaScriptBuffer `json:"payment_preimage,omitempty"`
-	PaymentRoute       *service.Route        `json:"route,omitempty"`
+	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
 }
 
 // KeySend : Key send Controller

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -34,7 +34,7 @@ type PayInvoiceResponseBody struct {
 	DescriptionHashStr string                `json:"description_hash,omitempty"`
 	PaymentError       string                `json:"payment_error,omitempty"`
 	PaymentPreimage    *lib.JavaScriptBuffer `json:"payment_preimage,omitempty"`
-	PaymentRoute       *service.Route        `json:"route,omitempty"`
+	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
 }
 
 // PayInvoice : Pay invoice Controller


### PR DESCRIPTION
Addresses the bug where `payment_route` in the pay responses was empty. We weren't following the Bluewallet spec here.