### PR TITLE
Add and use expected requests and responses for integration tests

### DIFF
--- a/integration_tests/auth_test.go
+++ b/integration_tests/auth_test.go
@@ -26,7 +26,7 @@ type UserAuthTestSuite struct {
 	suite.Suite
 	Service   *service.LndhubService
 	echo      *echo.Echo
-	userLogin controllers.CreateUserResponseBody
+	userLogin ExpectedCreateUserResponseBody
 }
 
 func (suite *UserAuthTestSuite) SetupSuite() {
@@ -54,7 +54,7 @@ func (suite *UserAuthTestSuite) TearDownSuite() {
 
 func (suite *UserAuthTestSuite) TestAuth() {
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		Login:    suite.userLogin.Login,
 		Password: suite.userLogin.Password,
 	}))
@@ -63,7 +63,7 @@ func (suite *UserAuthTestSuite) TestAuth() {
 	rec := httptest.NewRecorder()
 	c := suite.echo.NewContext(req, rec)
 	controller := controllers.NewAuthController(suite.Service)
-	responseBody := &controllers.AuthResponseBody{}
+	responseBody := &ExpectedAuthResponseBody{}
 	assert.NoError(suite.T(), controller.Auth(c))
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
@@ -72,7 +72,7 @@ func (suite *UserAuthTestSuite) TestAuth() {
 	fmt.Printf("Succesfully got a token using login and password: %s\n", responseBody.AccessToken)
 
 	// login again with only refresh token
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		RefreshToken: responseBody.RefreshToken,
 	}))
 	req = httptest.NewRequest(http.MethodPost, "/auth", &buf)
@@ -80,7 +80,7 @@ func (suite *UserAuthTestSuite) TestAuth() {
 	rec = httptest.NewRecorder()
 	c = suite.echo.NewContext(req, rec)
 	controller = controllers.NewAuthController(suite.Service)
-	responseBody = &controllers.AuthResponseBody{}
+	responseBody = &ExpectedAuthResponseBody{}
 	assert.NoError(suite.T(), controller.Auth(c))
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
@@ -92,7 +92,7 @@ func (suite *UserAuthTestSuite) TestAuth() {
 func (suite *UserAuthTestSuite) TestAuthWithExpiredRefreshToken() {
 	// log in with login and password
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		Login:    suite.userLogin.Login,
 		Password: suite.userLogin.Password,
 	}))
@@ -101,7 +101,7 @@ func (suite *UserAuthTestSuite) TestAuthWithExpiredRefreshToken() {
 	rec := httptest.NewRecorder()
 	c := suite.echo.NewContext(req, rec)
 	controller := controllers.NewAuthController(suite.Service)
-	responseBody := &controllers.AuthResponseBody{}
+	responseBody := &ExpectedAuthResponseBody{}
 	assert.NoError(suite.T(), controller.Auth(c))
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
@@ -114,7 +114,7 @@ func (suite *UserAuthTestSuite) TestAuthWithExpiredRefreshToken() {
 	expiredRefreshToken, _ := tokens.GenerateRefreshToken(suite.Service.Config.JWTSecret, 0, user)
 
 	// login again with only expired refresh token
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		RefreshToken: expiredRefreshToken,
 	}))
 
@@ -138,7 +138,7 @@ func (suite *UserAuthTestSuite) TestAuthWithExpiredRefreshToken() {
 func (suite *UserAuthTestSuite) TestAuthWithInvalidSecretRefreshToken() {
 	// log in with login and password
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		Login:    suite.userLogin.Login,
 		Password: suite.userLogin.Password,
 	}))
@@ -147,7 +147,7 @@ func (suite *UserAuthTestSuite) TestAuthWithInvalidSecretRefreshToken() {
 	rec := httptest.NewRecorder()
 	c := suite.echo.NewContext(req, rec)
 	controller := controllers.NewAuthController(suite.Service)
-	responseBody := &controllers.AuthResponseBody{}
+	responseBody := &ExpectedAuthResponseBody{}
 	assert.NoError(suite.T(), controller.Auth(c))
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
@@ -160,7 +160,7 @@ func (suite *UserAuthTestSuite) TestAuthWithInvalidSecretRefreshToken() {
 	expiredRefreshToken, _ := tokens.GenerateRefreshToken([]byte("INVALID SECRET"), suite.Service.Config.JWTRefreshTokenExpiry, user)
 
 	// login again with only refresh token
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		RefreshToken: expiredRefreshToken,
 	}))
 
@@ -181,7 +181,7 @@ func (suite *UserAuthTestSuite) TestAuthWithInvalidSecretRefreshToken() {
 func (suite *UserAuthTestSuite) TestAuthWithInvalidUserIdRefreshToken() {
 	// log in with login and password
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		Login:    suite.userLogin.Login,
 		Password: suite.userLogin.Password,
 	}))
@@ -190,7 +190,7 @@ func (suite *UserAuthTestSuite) TestAuthWithInvalidUserIdRefreshToken() {
 	rec := httptest.NewRecorder()
 	c := suite.echo.NewContext(req, rec)
 	controller := controllers.NewAuthController(suite.Service)
-	responseBody := &controllers.AuthResponseBody{}
+	responseBody := &ExpectedAuthResponseBody{}
 	assert.NoError(suite.T(), controller.Auth(c))
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
@@ -202,7 +202,7 @@ func (suite *UserAuthTestSuite) TestAuthWithInvalidUserIdRefreshToken() {
 	expiredRefreshToken, _ := tokens.GenerateRefreshToken(suite.Service.Config.JWTSecret, suite.Service.Config.JWTRefreshTokenExpiry, user)
 
 	// login again with only refresh token
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		RefreshToken: expiredRefreshToken,
 	}))
 
@@ -223,7 +223,7 @@ func (suite *UserAuthTestSuite) TestAuthWithInvalidUserIdRefreshToken() {
 func (suite *UserAuthTestSuite) TestAuthWithAccessToken() {
 	// log in with login and password
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		Login:    suite.userLogin.Login,
 		Password: suite.userLogin.Password,
 	}))
@@ -232,13 +232,13 @@ func (suite *UserAuthTestSuite) TestAuthWithAccessToken() {
 	rec := httptest.NewRecorder()
 	c := suite.echo.NewContext(req, rec)
 	controller := controllers.NewAuthController(suite.Service)
-	responseBody := &controllers.AuthResponseBody{}
+	responseBody := &ExpectedAuthResponseBody{}
 	assert.NoError(suite.T(), controller.Auth(c))
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
 
 	// login again with only access token
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		RefreshToken: responseBody.AccessToken,
 	}))
 
@@ -259,7 +259,7 @@ func (suite *UserAuthTestSuite) TestAuthWithAccessToken() {
 func (suite *UserAuthTestSuite) TestAuthWithNotParseableRefreshToken() {
 	var buf bytes.Buffer
 	// login with random not parseable refresh token
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AuthRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAuthRequestBody{
 		RefreshToken: "12345",
 	}))
 

--- a/integration_tests/checkpayment_test.go
+++ b/integration_tests/checkpayment_test.go
@@ -27,7 +27,7 @@ type CheckPaymentTestSuite struct {
 	TestSuite
 	fundingClient            *lnd.LNDWrapper
 	service                  *service.LndhubService
-	userLogin                controllers.CreateUserResponseBody
+	userLogin                ExpectedCreateUserResponseBody
 	userToken                string
 	invoiceUpdateSubCancelFn context.CancelFunc
 }
@@ -103,7 +103,7 @@ func (suite *CheckPaymentTestSuite) TestCheckPaymentProperIsPaidResponse() {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
 	rec := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
-	checkPaymentResponse := &controllers.CheckPaymentResponseBody{}
+	checkPaymentResponse := &ExpectedCheckPaymentResponseBody{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(checkPaymentResponse))
 	assert.False(suite.T(), checkPaymentResponse.IsPaid)
@@ -117,7 +117,7 @@ func (suite *CheckPaymentTestSuite) TestCheckPaymentProperIsPaidResponse() {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
 	rec = httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
-	checkPaymentResponse = &controllers.CheckPaymentResponseBody{}
+	checkPaymentResponse = &ExpectedCheckPaymentResponseBody{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(checkPaymentResponse))
 	assert.True(suite.T(), checkPaymentResponse.IsPaid)

--- a/integration_tests/create_test.go
+++ b/integration_tests/create_test.go
@@ -53,7 +53,7 @@ func (suite *CreateUserTestSuite) TestCreate() {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	controller := controllers.NewCreateUserController(suite.Service)
-	responseBody := controllers.CreateUserResponseBody{}
+	responseBody := ExpectedCreateUserResponseBody{}
 	if assert.NoError(suite.T(), controller.CreateUser(c)) {
 		assert.Equal(suite.T(), http.StatusOK, rec.Code)
 		assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
@@ -70,7 +70,7 @@ func (suite *CreateUserTestSuite) TestCreateWithProvidedLoginAndPassword() {
 	var buf bytes.Buffer
 	const testLogin = "test login"
 	const testPassword = "test password"
-	json.NewEncoder(&buf).Encode(&controllers.CreateUserRequestBody{
+	json.NewEncoder(&buf).Encode(&ExpectedCreateUserRequestBody{
 		Login:    testLogin,
 		Password: testPassword,
 	})
@@ -79,7 +79,7 @@ func (suite *CreateUserTestSuite) TestCreateWithProvidedLoginAndPassword() {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	controller := controllers.NewCreateUserController(suite.Service)
-	responseBody := controllers.CreateUserResponseBody{}
+	responseBody := ExpectedCreateUserResponseBody{}
 	if assert.NoError(suite.T(), controller.CreateUser(c)) {
 		assert.Equal(suite.T(), http.StatusOK, rec.Code)
 		assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))

--- a/integration_tests/expected_requests_and_responses.go
+++ b/integration_tests/expected_requests_and_responses.go
@@ -1,0 +1,109 @@
+package integration_tests
+
+import (
+	"github.com/getAlby/lndhub.go/lib"
+	"github.com/getAlby/lndhub.go/lib/service"
+)
+
+type ExpectedKeySendRequestBody struct {
+	Amount        int64             `json:"amount" validate:"required"`
+	Destination   string            `json:"destination" validate:"required"`
+	Memo          string            `json:"memo" validate:"omitempty"`
+	CustomRecords map[string]string `json:"customRecords" validate:"omitempty"`
+}
+
+type ExpectedKeySendResponseBody struct {
+	RHash              *lib.JavaScriptBuffer `json:"payment_hash,omitempty"`
+	Amount             int64                 `json:"num_satoshis,omitempty"`
+	Description        string                `json:"description,omitempty"`
+	Destination        string                `json:"destination,omitempty"`
+	DescriptionHashStr string                `json:"description_hash,omitempty"`
+	PaymentError       string                `json:"payment_error,omitempty"`
+	PaymentPreimage    *lib.JavaScriptBuffer `json:"payment_preimage,omitempty"`
+	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
+}
+
+type ExpectedAddInvoiceRequestBody struct {
+	Amount          interface{} `json:"amt"` // amount in Satoshi
+	Memo            string      `json:"memo"`
+	DescriptionHash string      `json:"description_hash" validate:"omitempty,hexadecimal,len=64"`
+}
+
+type ExpectedAddInvoiceResponseBody struct {
+	RHash          string `json:"r_hash"`
+	PaymentRequest string `json:"payment_request"`
+	PayReq         string `json:"pay_req"`
+}
+
+type ExpectedAuthRequestBody struct {
+	Login        string `json:"login"`
+	Password     string `json:"password"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type ExpectedAuthResponseBody struct {
+	RefreshToken string `json:"refresh_token"`
+	AccessToken  string `json:"access_token"`
+}
+
+type ExpectedBalanceResponse struct {
+	BTC struct {
+		AvailableBalance int64
+	}
+}
+
+type ExpectedCheckPaymentResponseBody struct {
+	IsPaid bool `json:"paid"`
+}
+
+type ExpectedCreateUserResponseBody struct {
+	Login    string `json:"login"`
+	Password string `json:"password"`
+}
+type ExpectedCreateUserRequestBody struct {
+	Login       string `json:"login"`
+	Password    string `json:"password"`
+	PartnerID   string `json:"partnerid"`
+	AccountType string `json:"accounttype"`
+}
+
+type ExpectedOutgoingInvoice struct {
+	RHash           interface{} `json:"r_hash"`
+	PaymentHash     interface{} `json:"payment_hash"`
+	PaymentPreimage string      `json:"payment_preimage"`
+	Value           int64       `json:"value"`
+	Type            string      `json:"type"`
+	Fee             int64       `json:"fee"`
+	Timestamp       int64       `json:"timestamp"`
+	Memo            string      `json:"memo"`
+}
+
+type ExpectedIncomingInvoice struct {
+	RHash          interface{} `json:"r_hash"`
+	PaymentHash    interface{} `json:"payment_hash"`
+	PaymentRequest string      `json:"payment_request"`
+	Description    string      `json:"description"`
+	PayReq         string      `json:"pay_req"`
+	Timestamp      int64       `json:"timestamp"`
+	Type           string      `json:"type"`
+	ExpireTime     int64       `json:"expire_time"`
+	Amount         int64       `json:"amt"`
+	IsPaid         bool        `json:"ispaid"`
+}
+
+type ExpectedPayInvoiceRequestBody struct {
+	Invoice string      `json:"invoice" validate:"required"`
+	Amount  interface{} `json:"amount" validate:"omitempty"`
+}
+
+type ExpectedPayInvoiceResponseBody struct {
+	RHash              *lib.JavaScriptBuffer `json:"payment_hash,omitempty"`
+	PaymentRequest     string                `json:"payment_request,omitempty"`
+	PayReq             string                `json:"pay_req,omitempty"`
+	Amount             int64                 `json:"num_satoshis,omitempty"`
+	Description        string                `json:"description,omitempty"`
+	DescriptionHashStr string                `json:"description_hash,omitempty"`
+	PaymentError       string                `json:"payment_error,omitempty"`
+	PaymentPreimage    *lib.JavaScriptBuffer `json:"payment_preimage,omitempty"`
+	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
+}

--- a/integration_tests/getinfo_test.go
+++ b/integration_tests/getinfo_test.go
@@ -23,7 +23,7 @@ import (
 type GetInfoTestSuite struct {
 	TestSuite
 	service   *service.LndhubService
-	userLogin controllers.CreateUserResponseBody
+	userLogin ExpectedCreateUserResponseBody
 	userToken string
 }
 

--- a/integration_tests/gettxs_test.go
+++ b/integration_tests/gettxs_test.go
@@ -27,7 +27,7 @@ type GetTxTestSuite struct {
 	TestSuite
 	Service                  *service.LndhubService
 	fundingClient            *lnd.LNDWrapper
-	userLogin                controllers.CreateUserResponseBody
+	userLogin                ExpectedCreateUserResponseBody
 	userToken                string
 	invoiceUpdateSubCancelFn context.CancelFunc
 }
@@ -84,7 +84,7 @@ func (suite *GetTxTestSuite) TestGetOutgoingInvoices() {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
 	rec := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
-	responseBody := &[]controllers.OutgoingInvoice{}
+	responseBody := &[]ExpectedOutgoingInvoice{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
 	assert.Empty(suite.T(), responseBody)
@@ -108,7 +108,7 @@ func (suite *GetTxTestSuite) TestGetOutgoingInvoices() {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
 	rec = httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
-	responseBody = &[]controllers.OutgoingInvoice{}
+	responseBody = &[]ExpectedOutgoingInvoice{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
 	assert.Equal(suite.T(), 1, len(*responseBody))
@@ -120,7 +120,7 @@ func (suite *GetTxTestSuite) TestGetIncomingInvoices() {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
 	rec := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
-	responseBody := &[]controllers.IncomingInvoice{}
+	responseBody := &[]ExpectedIncomingInvoice{}
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
 	assert.Empty(suite.T(), responseBody)
 	// create incoming invoice
@@ -131,7 +131,7 @@ func (suite *GetTxTestSuite) TestGetIncomingInvoices() {
 	rec = httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
 	// controller := controllers.NewGetTXSController(suite.Service)
-	responseBody = &[]controllers.IncomingInvoice{}
+	responseBody = &[]ExpectedIncomingInvoice{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&responseBody))
 	assert.Equal(suite.T(), 1, len(*responseBody))

--- a/integration_tests/incoming_payment_test.go
+++ b/integration_tests/incoming_payment_test.go
@@ -28,7 +28,7 @@ type IncomingPaymentTestSuite struct {
 	TestSuite
 	fundingClient            *lnd.LNDWrapper
 	service                  *service.LndhubService
-	userLogin                controllers.CreateUserResponseBody
+	userLogin                ExpectedCreateUserResponseBody
 	userToken                string
 	invoiceUpdateSubCancelFn context.CancelFunc
 }
@@ -81,7 +81,7 @@ func (suite *IncomingPaymentTestSuite) TestIncomingPayment() {
 	suite.echo.GET("/balance", controllers.NewBalanceController(suite.service).Balance)
 	suite.echo.POST("/addinvoice", controllers.NewAddInvoiceController(suite.service).AddInvoice)
 	suite.echo.ServeHTTP(rec, req)
-	balance := &controllers.BalanceResponse{}
+	balance := &ExpectedBalanceResponse{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&balance))
 	//assert the user has no balance to start with
@@ -103,7 +103,7 @@ func (suite *IncomingPaymentTestSuite) TestIncomingPayment() {
 	req = httptest.NewRequest(http.MethodGet, "/balance", &buf)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
 	suite.echo.ServeHTTP(rec, req)
-	balance = &controllers.BalanceResponse{}
+	balance = &ExpectedBalanceResponse{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(&balance))
 	//assert the balance was added to the user's account

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -25,9 +25,9 @@ type PaymentTestSuite struct {
 	TestSuite
 	fundingClient            *lnd.LNDWrapper
 	service                  *service.LndhubService
-	aliceLogin               controllers.CreateUserResponseBody
+	aliceLogin               ExpectedCreateUserResponseBody
 	aliceToken               string
-	bobLogin                 controllers.CreateUserResponseBody
+	bobLogin                 ExpectedCreateUserResponseBody
 	bobToken                 string
 	invoiceUpdateSubCancelFn context.CancelFunc
 }

--- a/integration_tests/invoice_test.go
+++ b/integration_tests/invoice_test.go
@@ -19,7 +19,7 @@ import (
 type InvoiceTestSuite struct {
 	TestSuite
 	service    *service.LndhubService
-	aliceLogin controllers.CreateUserResponseBody
+	aliceLogin ExpectedCreateUserResponseBody
 }
 
 func (suite *InvoiceTestSuite) SetupSuite() {

--- a/integration_tests/keysend_test.go
+++ b/integration_tests/keysend_test.go
@@ -24,7 +24,7 @@ type KeySendTestSuite struct {
 	TestSuite
 	fundingClient            *lnd.LNDWrapper
 	service                  *service.LndhubService
-	aliceLogin               controllers.CreateUserResponseBody
+	aliceLogin               ExpectedCreateUserResponseBody
 	aliceToken               string
 	invoiceUpdateSubCancelFn context.CancelFunc
 }

--- a/integration_tests/payment_failure_async_test.go
+++ b/integration_tests/payment_failure_async_test.go
@@ -25,7 +25,7 @@ type PaymentTestAsyncErrorsSuite struct {
 	TestSuite
 	fundingClient            *lnd.LNDWrapper
 	service                  *service.LndhubService
-	userLogin                controllers.CreateUserResponseBody
+	userLogin                ExpectedCreateUserResponseBody
 	userToken                string
 	invoiceUpdateSubCancelFn context.CancelFunc
 	serviceClient            *LNDMockWrapperAsync

--- a/integration_tests/payment_failure_test.go
+++ b/integration_tests/payment_failure_test.go
@@ -25,7 +25,7 @@ type PaymentTestErrorsSuite struct {
 	TestSuite
 	fundingClient            *lnd.LNDWrapper
 	service                  *service.LndhubService
-	userLogin                controllers.CreateUserResponseBody
+	userLogin                ExpectedCreateUserResponseBody
 	userToken                string
 	invoiceUpdateSubCancelFn context.CancelFunc
 }

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/getAlby/lndhub.go/controllers"
 	"github.com/getAlby/lndhub.go/db"
 	"github.com/getAlby/lndhub.go/db/migrations"
 	"github.com/getAlby/lndhub.go/lib"
@@ -114,15 +113,15 @@ func getUserIdFromToken(token string) int64 {
 	return int64(claims["id"].(float64))
 }
 
-func createUsers(svc *service.LndhubService, usersToCreate int) (logins []controllers.CreateUserResponseBody, tokens []string, err error) {
-	logins = []controllers.CreateUserResponseBody{}
+func createUsers(svc *service.LndhubService, usersToCreate int) (logins []ExpectedCreateUserResponseBody, tokens []string, err error) {
+	logins = []ExpectedCreateUserResponseBody{}
 	tokens = []string{}
 	for i := 0; i < usersToCreate; i++ {
 		user, err := svc.CreateUser(context.Background(), "", "")
 		if err != nil {
 			return nil, nil, err
 		}
-		var login controllers.CreateUserResponseBody
+		var login ExpectedCreateUserResponseBody
 		login.Login = user.Login
 		login.Password = user.Password
 		logins = append(logins, login)
@@ -147,10 +146,10 @@ func checkErrResponse(suite *TestSuite, rec *httptest.ResponseRecorder) *respons
 	return errorResponse
 }
 
-func (suite *TestSuite) createAddInvoiceReq(amt int, memo, token string) *controllers.AddInvoiceResponseBody {
+func (suite *TestSuite) createAddInvoiceReq(amt int, memo, token string) *ExpectedAddInvoiceResponseBody {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AddInvoiceRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAddInvoiceRequestBody{
 		Amount: amt,
 		Memo:   memo,
 	}))
@@ -158,23 +157,23 @@ func (suite *TestSuite) createAddInvoiceReq(amt int, memo, token string) *contro
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	suite.echo.ServeHTTP(rec, req)
-	invoiceResponse := &controllers.AddInvoiceResponseBody{}
+	invoiceResponse := &ExpectedAddInvoiceResponseBody{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(invoiceResponse))
 	return invoiceResponse
 }
 
-func (suite *TestSuite) createInvoiceReq(amt int, memo, userLogin string) *controllers.AddInvoiceResponseBody {
+func (suite *TestSuite) createInvoiceReq(amt int, memo, userLogin string) *ExpectedAddInvoiceResponseBody {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AddInvoiceRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAddInvoiceRequestBody{
 		Amount: amt,
 		Memo:   memo,
 	}))
 	req := httptest.NewRequest(http.MethodPost, "/invoice/"+userLogin, &buf)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	suite.echo.ServeHTTP(rec, req)
-	invoiceResponse := &controllers.AddInvoiceResponseBody{}
+	invoiceResponse := &ExpectedAddInvoiceResponseBody{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(invoiceResponse))
 	return invoiceResponse
@@ -183,7 +182,7 @@ func (suite *TestSuite) createInvoiceReq(amt int, memo, userLogin string) *contr
 func (suite *TestSuite) createInvoiceReqError(amt int, memo, userLogin string) *responses.ErrorResponse {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.AddInvoiceRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedAddInvoiceRequestBody{
 		Amount: amt,
 		Memo:   memo,
 	}))
@@ -193,10 +192,10 @@ func (suite *TestSuite) createInvoiceReqError(amt int, memo, userLogin string) *
 	return checkErrResponse(suite, rec)
 }
 
-func (suite *TestSuite) createKeySendReq(amount int64, memo, destination, token string) *controllers.KeySendResponseBody {
+func (suite *TestSuite) createKeySendReq(amount int64, memo, destination, token string) *ExpectedKeySendResponseBody {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.KeySendRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(ExpectedKeySendRequestBody{
 		Amount:      amount,
 		Destination: destination,
 		Memo:        memo,
@@ -208,7 +207,7 @@ func (suite *TestSuite) createKeySendReq(amount int64, memo, destination, token 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	suite.echo.ServeHTTP(rec, req)
 
-	keySendResponse := &controllers.KeySendResponseBody{}
+	keySendResponse := &ExpectedKeySendResponseBody{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(keySendResponse))
 	return keySendResponse
@@ -217,7 +216,7 @@ func (suite *TestSuite) createKeySendReq(amount int64, memo, destination, token 
 func (suite *TestSuite) createKeySendReqError(amount int64, memo, destination, token string) *responses.ErrorResponse {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.KeySendRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(ExpectedKeySendRequestBody{
 		Amount:      amount,
 		Destination: destination,
 		Memo:        memo,
@@ -229,10 +228,10 @@ func (suite *TestSuite) createKeySendReqError(amount int64, memo, destination, t
 	return checkErrResponse(suite, rec)
 }
 
-func (suite *TestSuite) createPayInvoiceReq(payReq string, token string) *controllers.PayInvoiceResponseBody {
+func (suite *TestSuite) createPayInvoiceReq(payReq string, token string) *ExpectedPayInvoiceResponseBody {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.PayInvoiceRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedPayInvoiceRequestBody{
 		Invoice: payReq,
 	}))
 	req := httptest.NewRequest(http.MethodPost, "/payinvoice", &buf)
@@ -240,7 +239,7 @@ func (suite *TestSuite) createPayInvoiceReq(payReq string, token string) *contro
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	suite.echo.ServeHTTP(rec, req)
 
-	payInvoiceResponse := &controllers.PayInvoiceResponseBody{}
+	payInvoiceResponse := &ExpectedPayInvoiceResponseBody{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(payInvoiceResponse))
 	return payInvoiceResponse
@@ -249,7 +248,7 @@ func (suite *TestSuite) createPayInvoiceReq(payReq string, token string) *contro
 func (suite *TestSuite) createPayInvoiceReqError(payReq string, token string) *responses.ErrorResponse {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.PayInvoiceRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedPayInvoiceRequestBody{
 		Invoice: payReq,
 	}))
 	req := httptest.NewRequest(http.MethodPost, "/payinvoice", &buf)
@@ -262,7 +261,7 @@ func (suite *TestSuite) createPayInvoiceReqError(payReq string, token string) *r
 func (suite *TestSuite) createPayInvoiceReqWithCancel(payReq string, token string) {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
-	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&controllers.PayInvoiceRequestBody{
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedPayInvoiceRequestBody{
 		Invoice: payReq,
 	}))
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
Added expected response and request structs for all integration tests, so in case they change on endpoints tests will fail.