### PR TITLE
always build docker images on every branch

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,8 +1,6 @@
 name: Docker build & push
 on:
   push:
-    branches:
-      - main
   release:
     types: [published]
 jobs:
@@ -30,6 +28,7 @@ jobs:
         token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
     # Always update dev environment 
     - name: Update dev environment
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: fjogeleit/yaml-update-action@v0.7.0
       with:
         valueFile: 'alby-simnet-deployment/values.yaml'


### PR DESCRIPTION
To easily test out new features, all branches should be containerized. However, only pushes to the main branch will be auto-deployed to the  dev environment.