### PR TITLE
always lowercase payreq

### DIFF
--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/getAlby/lndhub.go/lib"
 	"github.com/getAlby/lndhub.go/lib/responses"
@@ -52,6 +53,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	}
 
 	paymentRequest := reqBody.Invoice
+	paymentRequest = strings.ToLower(paymentRequest)
 	decodedPaymentRequest, err := controller.svc.DecodePaymentRequest(c.Request().Context(), paymentRequest)
 	if err != nil {
 		c.Logger().Errorf("Invalid payment request: %v", err)


### PR DESCRIPTION
When testing out Alby and Bluewallet on regtest, I noticed that Bluewallet puts in the invoice uppercase when calling `payinvoice`. This caused internal Alby payments to fail, as Alby could not find the invoice in the db.