### PR TITLE
deploy canary on new release

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,7 +46,7 @@ jobs:
       uses: fjogeleit/yaml-update-action@v0.7.0
       with:
         valueFile: 'alby-mainnet-deployment/values.yaml'
-        propertyPath: 'lndhub.image.tag'
+        propertyPath: 'lndhub-canary.image.tag'
         value: ${{ steps.build.outputs.tags }}
         repository: getalby/alby-deployment
         branch: main


### PR DESCRIPTION
Like this a new tag (release or tag pushed) will be auto-deployed in production on a seperate, canary deployment `lndhub-canary.mainnet.getalby.com`. This will allow us to do a test in production without pushing the release out to all users.