### PR TITLE
Fix: 0 amount incoming invoice

### DIFF
--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -81,7 +81,11 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 			InvoiceID:       invoice.ID,
 			CreditAccountID: creditAccount.ID,
 			DebitAccountID:  debitAccount.ID,
-			Amount:          invoice.Amount,
+			Amount:          rawInvoice.AmtPaidSat,
+		}
+
+		if rawInvoice.AmtPaidSat != invoice.Amount {
+			svc.Logger.Infof("Incoming invoice amount mismatch. Invoice id:%v, amt: %d, amt_paid: %d.", invoice.ID, invoice.Amount, rawInvoice.AmtPaidSat)
 		}
 
 		// Save the transaction entry

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -85,7 +85,7 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 		}
 
 		if rawInvoice.AmtPaidSat != invoice.Amount {
-			svc.Logger.Infof("Incoming invoice amount mismatch. Invoice id:%v, amt: %d, amt_paid: %d.", invoice.ID, invoice.Amount, rawInvoice.AmtPaidSat)
+			svc.Logger.Infof("Incoming invoice amount mismatch. user_id:%v invoice_id:%v, amt:%d, amt_paid:%d.", invoice.UserID, invoice.ID, invoice.Amount, rawInvoice.AmtPaidSat)
 		}
 
 		// Save the transaction entry


### PR DESCRIPTION
Fixes #165 

This credits the user's account the full amount that was paid for all incoming invoices. When there is a mismatch, a line is logged.
I pushed an integration test that reproduces the bug in the first commit.