### PR TITLE
Set cache-control headers for static routes (getinfo and home)

### DIFF
--- a/controllers/getinfo.ctrl.go
+++ b/controllers/getinfo.ctrl.go
@@ -95,5 +95,7 @@ func (controller *GetInfoController) GetInfo(c echo.Context) error {
 	}
 	// BlueWallet right now requires a `identity_pubkey` in the response
 	// https://github.com/BlueWallet/BlueWallet/blob/a28a2b96bce0bff6d1a24a951b59dc972369e490/class/wallets/lightning-custodian-wallet.js#L578
+
+  c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=300, stale-if-error=21600") // cache for 5 minutes or if error for 6 hours max
 	return c.JSON(http.StatusOK, info)
 }

--- a/controllers/home.ctrl.go
+++ b/controllers/home.ctrl.go
@@ -117,6 +117,7 @@ func (controller *HomeController) Home(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+  c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=300, stale-if-error=21600") // cache for 5 minutes or if error for 6 hours max
 	return c.HTMLBlob(http.StatusOK, buf.Bytes())
 }
 


### PR DESCRIPTION
This tells clients to cache the response for a few minutes and
thus makes it easier to run lndhub behind a proxy to cache static response