### PR TITLE
Feature/accept keysend

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If `WEBHOOK_URL` is specified, a http POST request will be dispatched at that lo
 
 Both incoming and outgoing keysend payments are supported. For outgoing keysend payments, check out the [API documentation](https://ln.getalby.com/swagger/index.html#/Payment/post_keysend).
 
-For incoming keysend payments, we are using a [custom TLV record with type `696969`](https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md#field-696969---lnpay), which should contain the hex-encoded `login` of the receiving user's account. Note that TLV records are not stored in the database. Webhook payloads do contain the TLV records, so they can be used to notify an external app of incoming keysend payments with TLV records (eg. a Boostagram reader).
+For incoming keysend payments, we are using a [custom TLV record with type `696969`](https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md#field-696969---lnpay), which should contain the hex-encoded `login` of the receiving user's account. TLV records are stored as json blobs with the invoices and are returned by the `/getuserinvoices` endpoint.
 
 ### Ideas
 + Using low level database constraints to prevent data inconsistencies

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ If `WEBHOOK_URL` is specified, a http POST request will be dispatched at that lo
 }
 ```
 
+## Keysend
+
+Both incoming and outgoing keysend payments are supported. For outgoing keysend payments, check out the [API documentation](https://ln.getalby.com/swagger/index.html#/Payment/post_keysend).
+
+For incoming keysend payments, we are using a [custom TLV record with type `696969`](https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md#field-696969---lnpay), which should contain the hex-encoded `login` of the receiving user's account. Note that TLV records are not stored in the database. Webhook payloads do contain the TLV records, so they can be used to notify an external app of incoming keysend payments with TLV records (eg. a Boostagram reader).
+
 ### Ideas
 + Using low level database constraints to prevent data inconsistencies
 + Follow double-entry bookkeeping ideas (Every transaction is a debit of one account and a credit to another one)

--- a/common/globals.go
+++ b/common/globals.go
@@ -15,4 +15,6 @@ const (
 	AccountTypeCurrent  = "current"
 	AccountTypeOutgoing = "outgoing"
 	AccountTypeFees     = "fees"
+
+	UserIdCustomRecordType = 696969 //cfr. https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md#field-696969---lnpay
 )

--- a/common/globals.go
+++ b/common/globals.go
@@ -15,6 +15,4 @@ const (
 	AccountTypeCurrent  = "current"
 	AccountTypeOutgoing = "outgoing"
 	AccountTypeFees     = "fees"
-
-	UserIdCustomRecordType = 696969 //cfr. https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md#field-696969---lnpay
 )

--- a/controllers/gettxs.ctrl.go
+++ b/controllers/gettxs.ctrl.go
@@ -19,27 +19,31 @@ func NewGetTXSController(svc *service.LndhubService) *GetTXSController {
 }
 
 type OutgoingInvoice struct {
-	RHash           interface{} `json:"r_hash,omitempty"`
-	PaymentHash     interface{} `json:"payment_hash"`
-	PaymentPreimage string      `json:"payment_preimage"`
-	Value           int64       `json:"value"`
-	Type            string      `json:"type"`
-	Fee             int64       `json:"fee"`
-	Timestamp       int64       `json:"timestamp"`
-	Memo            string      `json:"memo"`
+	RHash           interface{}       `json:"r_hash,omitempty"`
+	PaymentHash     interface{}       `json:"payment_hash"`
+	PaymentPreimage string            `json:"payment_preimage"`
+	Value           int64             `json:"value"`
+	Type            string            `json:"type"`
+	Fee             int64             `json:"fee"`
+	Timestamp       int64             `json:"timestamp"`
+	Memo            string            `json:"memo"`
+	Keysend         bool              `json:"keysend"`
+	CustomRecords   map[uint64][]byte `json:"custom_records"`
 }
 
 type IncomingInvoice struct {
-	RHash          interface{} `json:"r_hash,omitempty"`
-	PaymentHash    interface{} `json:"payment_hash"`
-	PaymentRequest string      `json:"payment_request"`
-	Description    string      `json:"description"`
-	PayReq         string      `json:"pay_req"`
-	Timestamp      int64       `json:"timestamp"`
-	Type           string      `json:"type"`
-	ExpireTime     int64       `json:"expire_time"`
-	Amount         int64       `json:"amt"`
-	IsPaid         bool        `json:"ispaid"`
+	RHash          interface{}       `json:"r_hash,omitempty"`
+	PaymentHash    interface{}       `json:"payment_hash"`
+	PaymentRequest string            `json:"payment_request"`
+	Description    string            `json:"description"`
+	PayReq         string            `json:"pay_req"`
+	Timestamp      int64             `json:"timestamp"`
+	Type           string            `json:"type"`
+	ExpireTime     int64             `json:"expire_time"`
+	Amount         int64             `json:"amt"`
+	IsPaid         bool              `json:"ispaid"`
+	Keysend        bool              `json:"keysend"`
+	CustomRecords  map[uint64][]byte `json:"custom_records"`
 }
 
 // GetTXS godoc
@@ -73,6 +77,8 @@ func (controller *GetTXSController) GetTXS(c echo.Context) error {
 			Fee:             invoice.Fee,
 			Timestamp:       invoice.CreatedAt.Unix(),
 			Memo:            invoice.Memo,
+			Keysend:         invoice.Keysend,
+			CustomRecords:   invoice.DestinationCustomRecords,
 		}
 	}
 	return c.JSON(http.StatusOK, &response)
@@ -111,6 +117,8 @@ func (controller *GetTXSController) GetUserInvoices(c echo.Context) error {
 			ExpireTime:     3600 * 24,
 			Amount:         invoice.Amount,
 			IsPaid:         invoice.State == common.InvoiceStateSettled,
+			Keysend:        invoice.Keysend,
+			CustomRecords:  invoice.DestinationCustomRecords,
 		}
 	}
 	return c.JSON(http.StatusOK, &response)

--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -41,7 +41,7 @@ type KeySendResponseBody struct {
 	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
 }
 
-//// PayInvoice godoc
+//// KeySend godoc
 // @Summary      Make a keysend payment
 // @Description  Pay a node without an invoice using it's public key
 // @Accept       json

--- a/db/migrations/20220518090000_custom_records.up.sql
+++ b/db/migrations/20220518090000_custom_records.up.sql
@@ -1,0 +1,2 @@
+
+alter table invoices add column destination_custom_records jsonb;

--- a/db/models/invoice.go
+++ b/db/models/invoice.go
@@ -19,7 +19,7 @@ type Invoice struct {
 	DescriptionHash          string            `json:"description_hash,omitempty" bun:",nullzero"`
 	PaymentRequest           string            `json:"payment_request" bun:",nullzero"`
 	DestinationPubkeyHex     string            `json:"destination_pubkey_hex" bun:",notnull"`
-	DestinationCustomRecords map[uint64][]byte `json:"custom_records,omitempty" bun:"-"`
+	DestinationCustomRecords map[uint64][]byte `json:"custom_records,omitempty"`
 	RHash                    string            `json:"r_hash"`
 	Preimage                 string            `json:"preimage" bun:",nullzero"`
 	Internal                 bool              `json:"-" bun:",nullzero"`

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -816,6 +816,15 @@ const docTemplate = `{
                 "amt": {
                     "type": "integer"
                 },
+                "custom_records": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "description": {
                     "type": "string"
                 },
@@ -823,6 +832,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "ispaid": {
+                    "type": "boolean"
+                },
+                "keysend": {
                     "type": "boolean"
                 },
                 "pay_req": {
@@ -908,8 +920,20 @@ const docTemplate = `{
         "controllers.OutgoingInvoice": {
             "type": "object",
             "properties": {
+                "custom_records": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "fee": {
                     "type": "integer"
+                },
+                "keysend": {
+                    "type": "boolean"
                 },
                 "memo": {
                     "type": "string"
@@ -1025,7 +1049,7 @@ var SwaggerInfo = &swag.Spec{
 	Version:          "0.6.1",
 	Host:             "",
 	BasePath:         "/",
-	Schemes:          []string{"http", "https"},
+	Schemes:          []string{"https", "http"},
 	Title:            "LNDhub.go",
 	Description:      "Accounting wrapper for the Lightning Network providing separate accounts for end-users.",
 	InfoInstanceName: "swagger",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,7 +1,7 @@
 {
     "schemes": [
-        "http",
-        "https"
+        "https",
+        "http"
     ],
     "swagger": "2.0",
     "info": {
@@ -812,6 +812,15 @@
                 "amt": {
                     "type": "integer"
                 },
+                "custom_records": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "description": {
                     "type": "string"
                 },
@@ -819,6 +828,9 @@
                     "type": "integer"
                 },
                 "ispaid": {
+                    "type": "boolean"
+                },
+                "keysend": {
                     "type": "boolean"
                 },
                 "pay_req": {
@@ -904,8 +916,20 @@
         "controllers.OutgoingInvoice": {
             "type": "object",
             "properties": {
+                "custom_records": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "fee": {
                     "type": "integer"
+                },
+                "keysend": {
+                    "type": "boolean"
                 },
                 "memo": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -157,11 +157,19 @@ definitions:
     properties:
       amt:
         type: integer
+      custom_records:
+        additionalProperties:
+          items:
+            type: integer
+          type: array
+        type: object
       description:
         type: string
       expire_time:
         type: integer
       ispaid:
+        type: boolean
+      keysend:
         type: boolean
       pay_req:
         type: string
@@ -218,8 +226,16 @@ definitions:
     type: object
   controllers.OutgoingInvoice:
     properties:
+      custom_records:
+        additionalProperties:
+          items:
+            type: integer
+          type: array
+        type: object
       fee:
         type: integer
+      keysend:
+        type: boolean
       memo:
         type: string
       payment_hash: {}
@@ -664,8 +680,8 @@ paths:
       tags:
       - Payment
 schemes:
-- http
 - https
+- http
 securityDefinitions:
   OAuth2Password:
     flow: password

--- a/integration_tests/expected_requests_and_responses.go
+++ b/integration_tests/expected_requests_and_responses.go
@@ -79,16 +79,18 @@ type ExpectedOutgoingInvoice struct {
 }
 
 type ExpectedIncomingInvoice struct {
-	RHash          interface{} `json:"r_hash"`
-	PaymentHash    interface{} `json:"payment_hash"`
-	PaymentRequest string      `json:"payment_request"`
-	Description    string      `json:"description"`
-	PayReq         string      `json:"pay_req"`
-	Timestamp      int64       `json:"timestamp"`
-	Type           string      `json:"type"`
-	ExpireTime     int64       `json:"expire_time"`
-	Amount         int64       `json:"amt"`
-	IsPaid         bool        `json:"ispaid"`
+	RHash          interface{}       `json:"r_hash"`
+	PaymentHash    interface{}       `json:"payment_hash"`
+	PaymentRequest string            `json:"payment_request"`
+	Description    string            `json:"description"`
+	PayReq         string            `json:"pay_req"`
+	Timestamp      int64             `json:"timestamp"`
+	Type           string            `json:"type"`
+	ExpireTime     int64             `json:"expire_time"`
+	Amount         int64             `json:"amt"`
+	IsPaid         bool              `json:"ispaid"`
+	Keysend        bool              `json:"keysend"`
+	CustomRecords  map[uint64][]byte `json:"custom_records"`
 }
 type ExpectedInvoiceEventWrapper struct {
 	Type    string                   `json:"type"`

--- a/integration_tests/incoming_payment_test.go
+++ b/integration_tests/incoming_payment_test.go
@@ -213,8 +213,14 @@ func (suite *IncomingPaymentTestSuite) TestIncomingPaymentKeysend() {
 	incomingPayments := &[]ExpectedIncomingInvoice{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(incomingPayments))
-	//keysend payment should be the last one
-	keySendPayment := (*incomingPayments)[len(*incomingPayments)-1]
+	//find the keysend payment, there should be only 1
+	var keySendPayment ExpectedIncomingInvoice
+	for _, payment := range *incomingPayments {
+		if payment.Keysend {
+			keySendPayment = payment
+			break
+		}
+	}
 	assert.True(suite.T(), keySendPayment.Keysend)
 	login := keySendPayment.CustomRecords[service.TLV_WALLET_ID]
 	assert.Equal(suite.T(), suite.userLogin.Login, string(login))

--- a/integration_tests/incoming_payment_test.go
+++ b/integration_tests/incoming_payment_test.go
@@ -154,7 +154,7 @@ func (suite *IncomingPaymentTestSuite) TestIncomingPaymentZeroAmt() {
 	//assert the payment value was added to the user's account
 	assert.Equal(suite.T(), initialBalance+int64(sendSatAmt), balance.BTC.AvailableBalance)
 }
-func (suite *IncomingPaymentTestSuite) TestIncomingKeysend() {
+func (suite *IncomingPaymentTestSuite) TestIncomingPaymentKeysend() {
 	var buf bytes.Buffer
 	req := httptest.NewRequest(http.MethodGet, "/balance", &buf)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -48,6 +48,14 @@ func (svc *LndhubService) FindInvoiceByPaymentHash(ctx context.Context, userId i
 
 func (svc *LndhubService) SendInternalPayment(ctx context.Context, invoice *models.Invoice) (SendPaymentResponse, error) {
 	sendPaymentResponse := SendPaymentResponse{}
+	//Check if it's a keysend payment
+	//If it is, an invoice will be created on-the-fly
+	if invoice.Keysend {
+		err := svc.HandleInternalKeysendPayment(ctx, invoice)
+		if err != nil {
+			return sendPaymentResponse, err
+		}
+	}
 	// find invoice
 	var incomingInvoice models.Invoice
 	err := svc.DB.NewSelect().Model(&incomingInvoice).Where("type = ? AND payment_request = ? AND state = ? ", common.InvoiceTypeIncoming, invoice.PaymentRequest, common.InvoiceStateOpen).Limit(1).Scan(ctx)

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -17,7 +17,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *lnrpc.Invoice) (err error) {
+func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *lnrpc.Invoice) error {
 	var invoice models.Invoice
 	rHashStr := hex.EncodeToString(rawInvoice.RHash)
 
@@ -50,7 +50,7 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 		}
 	}
 	// Search for an incoming invoice with the r_hash that is NOT settled in our DB
-	err = svc.DB.NewSelect().Model(&invoice).Where("type = ? AND r_hash = ? AND state <> ? AND expires_at > ?",
+	err := svc.DB.NewSelect().Model(&invoice).Where("type = ? AND r_hash = ? AND state <> ? AND expires_at > ?",
 		common.InvoiceTypeIncoming,
 		rHashStr,
 		common.InvoiceStateSettled,
@@ -137,11 +137,12 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 
 func (svc *LndhubService) createKeysendInvoice(ctx context.Context, rawInvoice *lnrpc.Invoice) (result models.Invoice, err error) {
 	//Look for the user-identifying TLV record
-	//which are located in the HTLC's. We only look at the first HTLC?
+	//which are located in the HTLC's.
+	//TODO: can the records differe from HTLC to HTLC? Probably not
 	if len(rawInvoice.Htlcs) == 0 {
 		return result, fmt.Errorf("Invoice's HTLC array has length 0")
 	}
-	userLoginCustomRecord := rawInvoice.Htlcs[0].CustomRecords[common.UserIdCustomRecordType]
+	userLoginCustomRecord := rawInvoice.Htlcs[0].CustomRecords[TLV_WALLET_ID]
 	//Find user. Our convention here is that the TLV
 	//record should contain the user's LNDhub login string
 	//(LND already returns the decoded string so there is no need to hex-decode it)
@@ -150,7 +151,7 @@ func (svc *LndhubService) createKeysendInvoice(ctx context.Context, rawInvoice *
 		return result, err
 	}
 
-	expiry := time.Hour * 24 // not really relevant here
+	expiry := time.Hour * 24 // not really relevant here, the invoice will be updated immediately
 	result = models.Invoice{
 		Type:                     common.InvoiceTypeIncoming,
 		UserID:                   user.ID,
@@ -216,8 +217,8 @@ func (svc *LndhubService) InvoiceUpdateSubscription(ctx context.Context) error {
 
 			processingError := svc.ProcessInvoiceUpdate(ctx, rawInvoice)
 			if processingError != nil {
-				svc.Logger.Error(processingError)
-				sentry.CaptureException(processingError)
+				svc.Logger.Error(fmt.Errorf("Error %s, invoice hash %s", processingError.Error(), hex.EncodeToString(rawInvoice.RHash)))
+				sentry.CaptureException(fmt.Errorf("Error %s, invoice hash %s", processingError.Error(), hex.EncodeToString(rawInvoice.RHash)))
 			}
 		}
 	}

--- a/lib/service/ln.go
+++ b/lib/service/ln.go
@@ -11,6 +11,8 @@ const (
 	KEYSEND_CUSTOM_RECORD = 5482373484
 	TLV_WHATSAT_MESSAGE   = 34349334
 	TLV_RECORD_NAME       = 128100
+
+	TLV_WALLET_ID = 696969 //cfr. https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md#field-696969---lnpay
 )
 
 func (svc *LndhubService) GetInfo(ctx context.Context) (*lnrpc.GetInfoResponse, error) {


### PR DESCRIPTION
Closes #169 

Process incoming keysend payments. The user login should be present in a TLV with type `696969`, as specified [here](https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md#field-696969---lnpay), and should be hex-encoded, although the decoding is done automatically by LND.

TLV records are stored in the database as json blobs with the invoices, and are returned by the `/getuserinvoices` endpoint (the values are base64 encoded):

```
...
        "amt": 100,
        "custom_records": {
            "696969": "TE9JMXdwQVdidnh4dE40aHB3Wno="
        },
        "description": "Keysend payment",
....
```

To test:
- Add an `lndhub.regtest.getalby.com` wallet to your Alby extension.
- Add simnet-lnd-2 to your Alby extension ([Instructions](https://github.com/getAlby/lightning-browser-extension/wiki/Test-setup#lnd-2))
- Use the following pen to send a keysend payment: https://codepen.io/kiwiidb/pen/MWQpjyp . Fill in your `lndhub.regtest.getalby.com` user ID in the last input field. Load the `simnet-lnd-2` wallet in the Alby extension and make the payment. The  payment should arrive in the `lndhub.regtest.getalby.com` account.