### PR TITLE
Don't defer close when the creation failed

### DIFF
--- a/controllers/invoicestream.ctrl.go
+++ b/controllers/invoicestream.ctrl.go
@@ -49,10 +49,10 @@ func (controller *InvoiceStreamController) StreamInvoices(c echo.Context) error 
 	invoiceChan := make(chan models.Invoice)
 	ticker := time.NewTicker(30 * time.Second)
 	ws, done, err := createWebsocketUpgrader(c)
-	defer ws.Close()
 	if err != nil {
 		return err
 	}
+	defer ws.Close()
 	//start subscription
 	subId, err := controller.svc.InvoicePubSub.Subscribe(strconv.FormatInt(userId, 10), invoiceChan)
 	if err != nil {


### PR DESCRIPTION
Found by running the latest `staticcheck` from https://github.com/dominikh/go-tools

Full report, but the rest are only nits (unused fields, deprecated fields, error string capitalization)

```
$ staticcheck ./...
controllers/invoicestream.ctrl.go:52:2: should check returned error before deferring ws.Close() (SA5001)
integration_tests/subscription_start_test.go:31:2: field invoiceUpdateSubCancelFn is unused (U1000)
integration_tests/websocket_test.go:137:2: this value of err is never used (SA4006)
lib/service/invoices.go:141:54: sendPaymentResult.PaymentRoute.TotalAmt is deprecated: Do not use.  (SA1019)
lib/service/invoices.go:141:106: sendPaymentResult.PaymentRoute.TotalFees is deprecated: Do not use.  (SA1019)
lib/service/invoicesubscription.go:66:10: error strings should not be capitalized (ST1005)
lib/service/invoicesubscription.go:111:93: rawInvoice.Settled is deprecated: Do not use.  (SA1019)
lib/service/invoicesubscription.go:134:6: rawInvoice.Settled is deprecated: Do not use.  (SA1019)
lib/service/invoicesubscription.go:187:18: error strings should not be capitalized (ST1005)
lib/service/invoicesubscription.go:239:11: error strings should not be capitalized (ST1005)
lib/service/invoicesubscription.go:265:22: error strings should not be capitalized (ST1005)
lib/service/invoicesubscription.go:266:29: error strings should not be capitalized (ST1005)
lib/tokens/jwt.go:104:14: error strings should not be capitalized (ST1005)
lib/tokens/jwt.go:110:15: error strings should not be capitalized (ST1005)
lib/tokens/jwt.go:118:14: error strings should not be capitalized (ST1005)
```