### PR TITLE
Make it possible to disable account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ vim .env # edit your config
 + `PROMETHEUS_PORT`: (default: 9092) Prometheus port (path: `/metrics`)
 + `WEBHOOK_URL`: Optional. Callback URL for incoming and outgoing payment events, see below.
 + `FEE_RESERVE`: (default: false) Keep fee reserve for each user
++ `ALLOW_ACCOUNT_CREATION`: (default: true) Enable creation of new accounts
 
 ## Developing
 

--- a/legacy_endpoints.go
+++ b/legacy_endpoints.go
@@ -13,7 +13,9 @@ import (
 func RegisterLegacyEndpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc) {
 	// Public endpoints for account creation and authentication
 	e.POST("/auth", controllers.NewAuthController(svc).Auth)
-	e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
+	if svc.Config.AllowAccountCreation {
+		e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
+	}
 	e.POST("/invoice/:user_login", controllers.NewInvoiceController(svc).Invoice, middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(svc.Config.DefaultRateLimit))))
 
 	// Secured endpoints which require a Authorization token (JWT)

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -20,4 +20,5 @@ type Config struct {
 	PrometheusPort        int    `envconfig:"PROMETHEUS_PORT" default:"9092"`
 	WebhookUrl            string `envconfig:"WEBHOOK_URL"`
 	FeeReserve            bool   `envconfig:"FEE_RESERVE" default:"false"`
+	AllowAccountCreation  bool   `envconfig:"ALLOW_ACCOUNT_CREATION" default:"true"`
 }

--- a/v2_endpoints.go
+++ b/v2_endpoints.go
@@ -9,7 +9,9 @@ import (
 func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc) {
 	// TODO: v2 auth endpoint: generalized oauth token generation
 	// e.POST("/auth", controllers.NewAuthController(svc).Auth)
-	e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
+	if svc.Config.AllowAccountCreation {
+		e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
+	}
 	invoiceCtrl := v2controllers.NewInvoiceController(svc)
 	secured.POST("/v2/invoices", invoiceCtrl.AddInvoice)
 	secured.GET("/v2/invoices/incoming", invoiceCtrl.GetIncomingInvoices)


### PR DESCRIPTION
This covers the usecase when LndHub is used to serve closed communities
which do not want to accept new members anymore (friends, families, etc).

The PR introduces a new envconfig option CREATE_ACCOUNTS which is true
by default but can be set to false if needed.