### PR TITLE
fix typo in error message

### DIFF
--- a/lib/responses/errors.go
+++ b/lib/responses/errors.go
@@ -35,7 +35,7 @@ var BadAuthError = ErrorResponse{
 var NotEnoughBalanceError = ErrorResponse{
 	Error:   true,
 	Code:    2,
-	Message: "not enough balance. Make sure you have at least 1%% reserved for potential fees",
+	Message: "not enough balance. Make sure you have at least 1% reserved for potential fees",
 }
 
 func HTTPErrorHandler(err error, c echo.Context) {


### PR DESCRIPTION
Tested with BlueWallet and ZeusLN and both show 1%% instead of 1%