### PR TITLE
Chore/v2 api

### DIFF
--- a/controllers/addinvoice.ctrl.go
+++ b/controllers/addinvoice.ctrl.go
@@ -30,18 +30,6 @@ type AddInvoiceResponseBody struct {
 	PayReq         string `json:"pay_req"`
 }
 
-// AddInvoice godoc
-// @Summary      Generate a new invoice
-// @Description  Returns a new bolt11 invoice
-// @Accept       json
-// @Produce      json
-// @Tags         Invoice
-// @Param        invoice  body      AddInvoiceRequestBody  True  "Add Invoice"
-// @Success      200      {object}  AddInvoiceResponseBody
-// @Failure      400      {object}  responses.ErrorResponse
-// @Failure      500      {object}  responses.ErrorResponse
-// @Router       /addinvoice [post]
-// @Security     OAuth2Password
 func (controller *AddInvoiceController) AddInvoice(c echo.Context) error {
 	userID := c.Get("UserID").(int64)
 	return AddInvoice(c, controller.svc, userID)

--- a/controllers/balance.ctrl.go
+++ b/controllers/balance.ctrl.go
@@ -22,17 +22,6 @@ type BalanceResponse struct {
 	}
 }
 
-// Balance godoc
-// @Summary      Retrieve balance
-// @Description  Current user's balance in satoshi
-// @Accept       json
-// @Produce      json
-// @Tags         Account
-// @Success      200  {object}  BalanceResponse
-// @Failure      400  {object}  responses.ErrorResponse
-// @Failure      500  {object}  responses.ErrorResponse
-// @Router       /balance [get]
-// @Security     OAuth2Password
 func (controller *BalanceController) Balance(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 	balance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userId)

--- a/controllers/checkpayment.ctrl.go
+++ b/controllers/checkpayment.ctrl.go
@@ -21,18 +21,6 @@ func NewCheckPaymentController(svc *service.LndhubService) *CheckPaymentControll
 	return &CheckPaymentController{svc: svc}
 }
 
-// CheckPayment godoc
-// @Summary      Check if an invoice is paid
-// @Description  Checks if an invoice is paid, can be incoming our outgoing
-// @Accept       json
-// @Produce      json
-// @Tags         Invoice
-// @Param        payment_hash  path      string  true  "Payment hash"
-// @Success      200           {object}  CheckPaymentResponseBody
-// @Failure      400           {object}  responses.ErrorResponse
-// @Failure      500           {object}  responses.ErrorResponse
-// @Router       /checkpayment/{payment_hash} [get]
-// @Security     OAuth2Password
 func (controller *CheckPaymentController) CheckPayment(c echo.Context) error {
 	userID := c.Get("UserID").(int64)
 	rHash := c.Param("payment_hash")

--- a/controllers/create.ctrl.go
+++ b/controllers/create.ctrl.go
@@ -28,17 +28,6 @@ type CreateUserRequestBody struct {
 	AccountType string `json:"accounttype"`
 }
 
-// CreateUser godoc
-// @Summary      Create an account
-// @Description  Create a new account with a login and password
-// @Accept       json
-// @Produce      json
-// @Tags         Account
-// @Param        account  body      CreateUserRequestBody  false  "Create User"
-// @Success      200      {object}  CreateUserResponseBody
-// @Failure      400      {object}  responses.ErrorResponse
-// @Failure      500      {object}  responses.ErrorResponse
-// @Router       /create [post]
 func (controller *CreateUserController) CreateUser(c echo.Context) error {
 
 	var body CreateUserRequestBody

--- a/controllers/getinfo.ctrl.go
+++ b/controllers/getinfo.ctrl.go
@@ -73,17 +73,6 @@ func NewGetInfoController(svc *service.LndhubService) *GetInfoController {
 	return &GetInfoController{svc: svc}
 }
 
-// GetInfo godoc
-// @Summary      Get info about the Lightning node
-// @Description  Returns info about the backend node powering this LNDhub instance
-// @Accept       json
-// @Produce      json
-// @Tags         Info
-// @Success      200  {object}  GetInfoResponse
-// @Failure      400  {object}  responses.ErrorResponse
-// @Failure      500  {object}  responses.ErrorResponse
-// @Router       /getinfo [get]
-// @Security     OAuth2Password
 func (controller *GetInfoController) GetInfo(c echo.Context) error {
 
 	info, err := controller.svc.GetInfo(c.Request().Context())
@@ -96,6 +85,6 @@ func (controller *GetInfoController) GetInfo(c echo.Context) error {
 	// BlueWallet right now requires a `identity_pubkey` in the response
 	// https://github.com/BlueWallet/BlueWallet/blob/a28a2b96bce0bff6d1a24a951b59dc972369e490/class/wallets/lightning-custodian-wallet.js#L578
 
-  c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=300, stale-if-error=21600") // cache for 5 minutes or if error for 6 hours max
+	c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=300, stale-if-error=21600") // cache for 5 minutes or if error for 6 hours max
 	return c.JSON(http.StatusOK, info)
 }

--- a/controllers/gettxs.ctrl.go
+++ b/controllers/gettxs.ctrl.go
@@ -46,17 +46,6 @@ type IncomingInvoice struct {
 	CustomRecords  map[uint64][]byte `json:"custom_records"`
 }
 
-// GetTXS godoc
-// @Summary      Retrieve outgoing payments
-// @Description  Returns a list of outgoing payments for a user
-// @Accept       json
-// @Produce      json
-// @Tags         Account
-// @Success      200  {object}  []OutgoingInvoice
-// @Failure      400  {object}  responses.ErrorResponse
-// @Failure      500  {object}  responses.ErrorResponse
-// @Router       /gettxs [get]
-// @Security     OAuth2Password
 func (controller *GetTXSController) GetTXS(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 
@@ -84,17 +73,6 @@ func (controller *GetTXSController) GetTXS(c echo.Context) error {
 	return c.JSON(http.StatusOK, &response)
 }
 
-// GetUserInvoices godoc
-// @Summary      Retrieve incoming invoices
-// @Description  Returns a list of incoming invoices for a user
-// @Accept       json
-// @Produce      json
-// @Tags         Account
-// @Success      200  {object}  []IncomingInvoice
-// @Failure      400  {object}  responses.ErrorResponse
-// @Failure      500  {object}  responses.ErrorResponse
-// @Router       /getuserinvoices [get]
-// @Security     OAuth2Password
 func (controller *GetTXSController) GetUserInvoices(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 

--- a/controllers/invoice.ctrl.go
+++ b/controllers/invoice.ctrl.go
@@ -17,18 +17,6 @@ func NewInvoiceController(svc *service.LndhubService) *InvoiceController {
 	return &InvoiceController{svc: svc}
 }
 
-// Invoice godoc
-// @Summary      Generate a new invoice
-// @Description  Returns a new bolt11 invoice for a user with given login, without an Authorization Header
-// @Accept       json
-// @Produce      json
-// @Tags         Invoice
-// @Param        user_login  path      string                 true  "User Login"
-// @Param        invoice     body      AddInvoiceRequestBody  True  "Add Invoice"
-// @Success      200         {object}  AddInvoiceResponseBody
-// @Failure      400         {object}  responses.ErrorResponse
-// @Failure      500         {object}  responses.ErrorResponse
-// @Router       /invoice/{user_login} [post]
 func (controller *InvoiceController) Invoice(c echo.Context) error {
 	user, err := controller.svc.FindUserByLogin(c.Request().Context(), c.Param("user_login"))
 	if err != nil {

--- a/controllers/invoicestream.ctrl.go
+++ b/controllers/invoicestream.ctrl.go
@@ -27,20 +27,6 @@ func NewInvoiceStreamController(svc *service.LndhubService) *InvoiceStreamContro
 	return &InvoiceStreamController{svc: svc}
 }
 
-// StreamInvoices godoc
-// @Summary      Websocket for incoming payments
-// @Description  Websocket: won't work with Swagger web UI. Returns a stream of settled incoming payments.
-// @Description  A keep-alive message is sent on startup and every 30s.
-// @Accept       json
-// @Produce      json
-// @Tags         Invoice
-// @Param        token               query     string  true   "Auth token, retrieved from /auth endpoint"
-// @Param        since_payment_hash  query     string  false  "Payment hash of earliest invoice. If specified, missing updates starting from this payment will be sent."
-// @Success      200                 {object}  []InvoiceEventWrapper
-// @Failure      400                 {object}  responses.ErrorResponse
-// @Failure      500                 {object}  responses.ErrorResponse
-// @Router       /invoices/stream [get]
-// @Security     OAuth2Password
 func (controller *InvoiceStreamController) StreamInvoices(c echo.Context) error {
 	userId, err := tokens.ParseToken(controller.svc.Config.JWTSecret, (c.QueryParam("token")), false)
 	if err != nil {

--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -41,18 +41,6 @@ type KeySendResponseBody struct {
 	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
 }
 
-//// KeySend godoc
-// @Summary      Make a keysend payment
-// @Description  Pay a node without an invoice using it's public key
-// @Accept       json
-// @Produce      json
-// @Tags         Payment
-// @Param        KeySendRequestBody  body      KeySendRequestBody  True  "Invoice to pay"
-// @Success      200                 {object}  KeySendResponseBody
-// @Failure      400                 {object}  responses.ErrorResponse
-// @Failure      500                 {object}  responses.ErrorResponse
-// @Router       /keysend [post]
-// @Security     OAuth2Password
 func (controller *KeySendController) KeySend(c echo.Context) error {
 	userID := c.Get("UserID").(int64)
 	reqBody := KeySendRequestBody{}

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -39,18 +39,6 @@ type PayInvoiceResponseBody struct {
 	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
 }
 
-// PayInvoice godoc
-// @Summary      Pay an invoice
-// @Description  Pay a bolt11 invoice
-// @Accept       json
-// @Produce      json
-// @Tags         Payment
-// @Param        PayInvoiceRequest  body      PayInvoiceRequestBody  True  "Invoice to pay"
-// @Success      200                {object}  PayInvoiceResponseBody
-// @Failure      400                {object}  responses.ErrorResponse
-// @Failure      500                {object}  responses.ErrorResponse
-// @Router       /payinvoice [post]
-// @Security     OAuth2Password
 func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	userID := c.Get("UserID").(int64)
 	reqBody := PayInvoiceRequestBody{}

--- a/controllers_v2/balance.ctrl.go
+++ b/controllers_v2/balance.ctrl.go
@@ -17,9 +17,9 @@ func NewBalanceController(svc *service.LndhubService) *BalanceController {
 }
 
 type BalanceResponse struct {
-	BTC struct {
-		AvailableBalance int64
-	}
+	Balance  int64  `json:"balance"`
+	Currency string `json:"currency"`
+	Unit     string `json:"unit"`
 }
 
 // Balance godoc
@@ -31,7 +31,7 @@ type BalanceResponse struct {
 // @Success      200  {object}  BalanceResponse
 // @Failure      400  {object}  responses.ErrorResponse
 // @Failure      500  {object}  responses.ErrorResponse
-// @Router       /balance [get]
+// @Router       /v2/balance [get]
 // @Security     OAuth2Password
 func (controller *BalanceController) Balance(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
@@ -40,8 +40,8 @@ func (controller *BalanceController) Balance(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, &BalanceResponse{
-		BTC: struct{ AvailableBalance int64 }{
-			AvailableBalance: balance,
-		},
+		Balance:  balance,
+		Currency: "BTC",
+		Unit:     "sat",
 	})
 }

--- a/controllers_v2/balance.ctrl.go
+++ b/controllers_v2/balance.ctrl.go
@@ -1,0 +1,47 @@
+package v2controllers
+
+import (
+	"net/http"
+
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/labstack/echo/v4"
+)
+
+// BalanceController : BalanceController struct
+type BalanceController struct {
+	svc *service.LndhubService
+}
+
+func NewBalanceController(svc *service.LndhubService) *BalanceController {
+	return &BalanceController{svc: svc}
+}
+
+type BalanceResponse struct {
+	BTC struct {
+		AvailableBalance int64
+	}
+}
+
+// Balance godoc
+// @Summary      Retrieve balance
+// @Description  Current user's balance in satoshi
+// @Accept       json
+// @Produce      json
+// @Tags         Account
+// @Success      200  {object}  BalanceResponse
+// @Failure      400  {object}  responses.ErrorResponse
+// @Failure      500  {object}  responses.ErrorResponse
+// @Router       /balance [get]
+// @Security     OAuth2Password
+func (controller *BalanceController) Balance(c echo.Context) error {
+	userId := c.Get("UserID").(int64)
+	balance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userId)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, &BalanceResponse{
+		BTC: struct{ AvailableBalance int64 }{
+			AvailableBalance: balance,
+		},
+	})
+}

--- a/controllers_v2/create.ctrl.go
+++ b/controllers_v2/create.ctrl.go
@@ -1,0 +1,59 @@
+package v2controllers
+
+import (
+	"net/http"
+
+	"github.com/getAlby/lndhub.go/lib/responses"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/labstack/echo/v4"
+)
+
+// CreateUserController : Create user controller struct
+type CreateUserController struct {
+	svc *service.LndhubService
+}
+
+func NewCreateUserController(svc *service.LndhubService) *CreateUserController {
+	return &CreateUserController{svc: svc}
+}
+
+type CreateUserResponseBody struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+type CreateUserRequestBody struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// CreateUser godoc
+// @Summary      Create an account
+// @Description  Create a new account with a username and password
+// @Accept       json
+// @Produce      json
+// @Tags         Account
+// @Param        account  body      CreateUserRequestBody  false  "Create User"
+// @Success      200      {object}  CreateUserResponseBody
+// @Failure      400      {object}  responses.ErrorResponse
+// @Failure      500      {object}  responses.ErrorResponse
+// @Router       /v2/users [post]
+func (controller *CreateUserController) CreateUser(c echo.Context) error {
+
+	var body CreateUserRequestBody
+
+	if err := c.Bind(&body); err != nil {
+		c.Logger().Errorf("Failed to load create user request body: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+	user, err := controller.svc.CreateUser(c.Request().Context(), body.Username, body.Password)
+	if err != nil {
+		c.Logger().Errorf("Failed to create user: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	var ResponseBody CreateUserResponseBody
+	ResponseBody.Username = user.Login
+	ResponseBody.Password = user.Password
+
+	return c.JSON(http.StatusOK, &ResponseBody)
+}

--- a/controllers_v2/invoice.ctrl.go
+++ b/controllers_v2/invoice.ctrl.go
@@ -1,0 +1,188 @@
+package v2controllers
+
+import (
+	"net/http"
+
+	"github.com/getAlby/lndhub.go/common"
+	"github.com/getAlby/lndhub.go/lib"
+	"github.com/getAlby/lndhub.go/lib/responses"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/getsentry/sentry-go"
+	"github.com/labstack/echo/v4"
+)
+
+// InvoiceController : Add invoice controller struct
+type InvoiceController struct {
+	svc *service.LndhubService
+}
+
+func NewInvoiceController(svc *service.LndhubService) *InvoiceController {
+	return &InvoiceController{svc: svc}
+}
+
+type OutgoingInvoice struct {
+	RHash           interface{}       `json:"r_hash,omitempty"`
+	PaymentHash     interface{}       `json:"payment_hash"`
+	PaymentPreimage string            `json:"payment_preimage"`
+	Value           int64             `json:"value"`
+	Type            string            `json:"type"`
+	Fee             int64             `json:"fee"`
+	Timestamp       int64             `json:"timestamp"`
+	Memo            string            `json:"memo"`
+	Keysend         bool              `json:"keysend"`
+	CustomRecords   map[uint64][]byte `json:"custom_records"`
+}
+
+type IncomingInvoice struct {
+	RHash          interface{}       `json:"r_hash,omitempty"`
+	PaymentHash    interface{}       `json:"payment_hash"`
+	PaymentRequest string            `json:"payment_request"`
+	Description    string            `json:"description"`
+	PayReq         string            `json:"pay_req"`
+	Timestamp      int64             `json:"timestamp"`
+	Type           string            `json:"type"`
+	ExpireTime     int64             `json:"expire_time"`
+	Amount         int64             `json:"amt"`
+	IsPaid         bool              `json:"ispaid"`
+	Keysend        bool              `json:"keysend"`
+	CustomRecords  map[uint64][]byte `json:"custom_records"`
+}
+
+// GetTXS godoc
+// @Summary      Retrieve outgoing payments
+// @Description  Returns a list of outgoing payments for a user
+// @Accept       json
+// @Produce      json
+// @Tags         Account
+// @Success      200  {object}  []OutgoingInvoice
+// @Failure      400  {object}  responses.ErrorResponse
+// @Failure      500  {object}  responses.ErrorResponse
+// @Router       /gettxs [get]
+// @Security     OAuth2Password
+func (controller *InvoiceController) GetOutgoingInvoices(c echo.Context) error {
+	userId := c.Get("UserID").(int64)
+
+	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeOutgoing)
+	if err != nil {
+		return err
+	}
+
+	response := make([]OutgoingInvoice, len(invoices))
+	for i, invoice := range invoices {
+		rhash, _ := lib.ToJavaScriptBuffer(invoice.RHash)
+		response[i] = OutgoingInvoice{
+			RHash:           rhash,
+			PaymentHash:     rhash,
+			PaymentPreimage: invoice.Preimage,
+			Value:           invoice.Amount,
+			Type:            common.InvoiceTypePaid,
+			Fee:             invoice.Fee,
+			Timestamp:       invoice.CreatedAt.Unix(),
+			Memo:            invoice.Memo,
+			Keysend:         invoice.Keysend,
+			CustomRecords:   invoice.DestinationCustomRecords,
+		}
+	}
+	return c.JSON(http.StatusOK, &response)
+}
+
+// GetUserInvoices godoc
+// @Summary      Retrieve incoming invoices
+// @Description  Returns a list of incoming invoices for a user
+// @Accept       json
+// @Produce      json
+// @Tags         Account
+// @Success      200  {object}  []IncomingInvoice
+// @Failure      400  {object}  responses.ErrorResponse
+// @Failure      500  {object}  responses.ErrorResponse
+// @Router       /getuserinvoices [get]
+// @Security     OAuth2Password
+func (controller *InvoiceController) GetIncomingInvoices(c echo.Context) error {
+	userId := c.Get("UserID").(int64)
+
+	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeIncoming)
+	if err != nil {
+		return err
+	}
+
+	response := make([]IncomingInvoice, len(invoices))
+	for i, invoice := range invoices {
+		rhash, _ := lib.ToJavaScriptBuffer(invoice.RHash)
+		response[i] = IncomingInvoice{
+			RHash:          rhash,
+			PaymentHash:    invoice.RHash,
+			PaymentRequest: invoice.PaymentRequest,
+			Description:    invoice.Memo,
+			PayReq:         invoice.PaymentRequest,
+			Timestamp:      invoice.CreatedAt.Unix(),
+			Type:           common.InvoiceTypeUser,
+			ExpireTime:     3600 * 24,
+			Amount:         invoice.Amount,
+			IsPaid:         invoice.State == common.InvoiceStateSettled,
+			Keysend:        invoice.Keysend,
+			CustomRecords:  invoice.DestinationCustomRecords,
+		}
+	}
+	return c.JSON(http.StatusOK, &response)
+}
+
+type AddInvoiceRequestBody struct {
+	Amount          interface{} `json:"amt"` // amount in Satoshi
+	Memo            string      `json:"memo"`
+	DescriptionHash string      `json:"description_hash" validate:"omitempty,hexadecimal,len=64"`
+}
+
+type AddInvoiceResponseBody struct {
+	RHash          string `json:"r_hash"`
+	PaymentRequest string `json:"payment_request"`
+	PayReq         string `json:"pay_req"`
+}
+
+// AddInvoice godoc
+// @Summary      Generate a new invoice
+// @Description  Returns a new bolt11 invoice
+// @Accept       json
+// @Produce      json
+// @Tags         Invoice
+// @Param        invoice  body      AddInvoiceRequestBody  True  "Add Invoice"
+// @Success      200      {object}  AddInvoiceResponseBody
+// @Failure      400      {object}  responses.ErrorResponse
+// @Failure      500      {object}  responses.ErrorResponse
+// @Router       /addinvoice [post]
+// @Security     OAuth2Password
+func (controller *InvoiceController) AddInvoice(c echo.Context) error {
+	userID := c.Get("UserID").(int64)
+	var body AddInvoiceRequestBody
+
+	if err := c.Bind(&body); err != nil {
+		c.Logger().Errorf("Failed to load addinvoice request body: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	if err := c.Validate(&body); err != nil {
+		c.Logger().Errorf("Invalid addinvoice request body: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	amount, err := controller.svc.ParseInt(body.Amount)
+	if err != nil || amount < 0 {
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+	c.Logger().Infof("Adding invoice: user_id:%v memo:%s value:%v description_hash:%s", userID, body.Memo, amount, body.DescriptionHash)
+
+	invoice, err := controller.svc.AddIncomingInvoice(c.Request().Context(), userID, amount, body.Memo, body.DescriptionHash)
+	if err != nil {
+		c.Logger().Errorf("Error creating invoice: user_id:%v error: %v", userID, err)
+		sentry.CaptureException(err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+	responseBody := AddInvoiceResponseBody{}
+	responseBody.RHash = invoice.RHash
+	responseBody.PaymentRequest = invoice.PaymentRequest
+	responseBody.PayReq = invoice.PaymentRequest
+
+	return c.JSON(http.StatusOK, &responseBody)
+}
+func (controller *InvoiceController) GetInvoice(c echo.Context) error {
+	return nil
+}

--- a/controllers_v2/invoice.ctrl.go
+++ b/controllers_v2/invoice.ctrl.go
@@ -44,7 +44,7 @@ type Invoice struct {
 // @Description  Returns a list of outgoing payments for a user
 // @Accept       json
 // @Produce      json
-// @Tags         Account
+// @Tags         Invoice
 // @Success      200  {object}  []Invoice
 // @Failure      400  {object}  responses.ErrorResponse
 // @Failure      500  {object}  responses.ErrorResponse
@@ -87,7 +87,7 @@ func (controller *InvoiceController) GetOutgoingInvoices(c echo.Context) error {
 // @Description  Returns a list of incoming invoices for a user
 // @Accept       json
 // @Produce      json
-// @Tags         Account
+// @Tags         Invoice
 // @Success      200  {object}  []Invoice
 // @Failure      400  {object}  responses.ErrorResponse
 // @Failure      500  {object}  responses.ErrorResponse
@@ -184,7 +184,7 @@ func (controller *InvoiceController) AddInvoice(c echo.Context) error {
 // @Description  Retrieve information about a specific invoice by payment hash
 // @Accept       json
 // @Produce      json
-// @Tags         Account
+// @Tags         Invoice
 // @Param        payment_hash  path      string  true  "Payment hash"
 // @Success      200  {object}  Invoice
 // @Failure      400  {object}  responses.ErrorResponse

--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -1,0 +1,127 @@
+package v2controllers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/getAlby/lndhub.go/lib"
+	"github.com/getAlby/lndhub.go/lib/responses"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/getAlby/lndhub.go/lnd"
+	"github.com/getsentry/sentry-go"
+	"github.com/labstack/echo/v4"
+	"github.com/lightningnetwork/lnd/lnrpc"
+)
+
+// KeySendController : Key send controller struct
+type KeySendController struct {
+	svc *service.LndhubService
+}
+
+func NewKeySendController(svc *service.LndhubService) *KeySendController {
+	return &KeySendController{svc: svc}
+}
+
+type KeySendRequestBody struct {
+	Amount        int64             `json:"amount" validate:"required,gt=0"`
+	Destination   string            `json:"destination" validate:"required"`
+	Memo          string            `json:"memo" validate:"omitempty"`
+	CustomRecords map[string]string `json:"customRecords" validate:"omitempty"`
+}
+
+type KeySendResponseBody struct {
+	RHash              *lib.JavaScriptBuffer `json:"payment_hash,omitempty"`
+	Amount             int64                 `json:"num_satoshis,omitempty"`
+	Description        string                `json:"description,omitempty"`
+	Destination        string                `json:"destination,omitempty"`
+	DescriptionHashStr string                `json:"description_hash,omitempty"`
+	PaymentError       string                `json:"payment_error,omitempty"`
+	PaymentPreimage    *lib.JavaScriptBuffer `json:"payment_preimage,omitempty"`
+	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
+}
+
+//// KeySend godoc
+// @Summary      Make a keysend payment
+// @Description  Pay a node without an invoice using it's public key
+// @Accept       json
+// @Produce      json
+// @Tags         Payment
+// @Param        KeySendRequestBody  body      KeySendRequestBody  True  "Invoice to pay"
+// @Success      200                 {object}  KeySendResponseBody
+// @Failure      400                 {object}  responses.ErrorResponse
+// @Failure      500                 {object}  responses.ErrorResponse
+// @Router       /keysend [post]
+// @Security     OAuth2Password
+func (controller *KeySendController) KeySend(c echo.Context) error {
+	userID := c.Get("UserID").(int64)
+	reqBody := KeySendRequestBody{}
+	if err := c.Bind(&reqBody); err != nil {
+		c.Logger().Errorf("Failed to load keysend request body: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	if err := c.Validate(&reqBody); err != nil {
+		c.Logger().Errorf("Invalid keysend request body: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	lnPayReq := &lnd.LNPayReq{
+		PayReq: &lnrpc.PayReq{
+			Destination: reqBody.Destination,
+			NumSatoshis: reqBody.Amount,
+			Description: reqBody.Memo,
+		},
+		Keysend: true,
+	}
+
+	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, "", lnPayReq)
+	if err != nil {
+		return err
+	}
+
+	currentBalance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userID)
+	if err != nil {
+		return err
+	}
+
+	minimumBalance := invoice.Amount
+	if controller.svc.Config.FeeReserve {
+		minimumBalance += invoice.CalcFeeLimit()
+	}
+	if currentBalance < minimumBalance {
+		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)
+		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
+	}
+
+	invoice.DestinationCustomRecords = map[uint64][]byte{}
+	for key, value := range reqBody.CustomRecords {
+		intKey, err := strconv.Atoi(key)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+		}
+		invoice.DestinationCustomRecords[uint64(intKey)] = []byte(value)
+	}
+	sendPaymentResponse, err := controller.svc.PayInvoice(c.Request().Context(), invoice)
+	if err != nil {
+		c.Logger().Errorf("Payment failed: user_id:%v error: %v", userID, err)
+		sentry.CaptureException(err)
+		return c.JSON(http.StatusBadRequest, echo.Map{
+			"error":   true,
+			"code":    10,
+			"message": fmt.Sprintf("Payment failed. Does the receiver have enough inbound capacity? (%v)", err),
+		})
+	}
+
+	responseBody := &KeySendResponseBody{}
+	responseBody.RHash = &lib.JavaScriptBuffer{Data: sendPaymentResponse.PaymentHash}
+	responseBody.Amount = invoice.Amount
+	responseBody.Destination = invoice.DestinationPubkeyHex
+	responseBody.Description = invoice.Memo
+	responseBody.DescriptionHashStr = invoice.DescriptionHash
+	responseBody.PaymentError = sendPaymentResponse.PaymentError
+	responseBody.PaymentPreimage = &lib.JavaScriptBuffer{Data: sendPaymentResponse.PaymentPreimage}
+	responseBody.PaymentRoute = sendPaymentResponse.PaymentRoute
+
+	return c.JSON(http.StatusOK, responseBody)
+}

--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -1,11 +1,9 @@
 package v2controllers
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
-	"github.com/getAlby/lndhub.go/lib"
 	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/service"
 	"github.com/getAlby/lndhub.go/lnd"
@@ -31,14 +29,14 @@ type KeySendRequestBody struct {
 }
 
 type KeySendResponseBody struct {
-	RHash              *lib.JavaScriptBuffer `json:"payment_hash,omitempty"`
-	Amount             int64                 `json:"num_satoshis,omitempty"`
-	Description        string                `json:"description,omitempty"`
-	Destination        string                `json:"destination,omitempty"`
-	DescriptionHashStr string                `json:"description_hash,omitempty"`
-	PaymentError       string                `json:"payment_error,omitempty"`
-	PaymentPreimage    *lib.JavaScriptBuffer `json:"payment_preimage,omitempty"`
-	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
+	Amount          int64  `json:"amount,omitempty"`
+	Fee             int64  `json:"fee,omitempty"`
+	Description     string `json:"description,omitempty"`
+	DescriptionHash string `json:"description_hash,omitempty"`
+	Destination     string `json:"destination,omitempty"`
+	PaymentError    string `json:"payment_error,omitempty"`
+	PaymentPreimage string `json:"payment_preimage,omitempty"`
+	PaymentHash     string `json:"payment_hash,omitempty"`
 }
 
 //// KeySend godoc
@@ -51,7 +49,7 @@ type KeySendResponseBody struct {
 // @Success      200                 {object}  KeySendResponseBody
 // @Failure      400                 {object}  responses.ErrorResponse
 // @Failure      500                 {object}  responses.ErrorResponse
-// @Router       /keysend [post]
+// @Router       /v2/payments/keysend [post]
 // @Security     OAuth2Password
 func (controller *KeySendController) KeySend(c echo.Context) error {
 	userID := c.Get("UserID").(int64)
@@ -109,19 +107,20 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, echo.Map{
 			"error":   true,
 			"code":    10,
-			"message": fmt.Sprintf("Payment failed. Does the receiver have enough inbound capacity? (%v)", err),
+			"message": err.Error(),
 		})
 	}
 
-	responseBody := &KeySendResponseBody{}
-	responseBody.RHash = &lib.JavaScriptBuffer{Data: sendPaymentResponse.PaymentHash}
-	responseBody.Amount = invoice.Amount
-	responseBody.Destination = invoice.DestinationPubkeyHex
-	responseBody.Description = invoice.Memo
-	responseBody.DescriptionHashStr = invoice.DescriptionHash
-	responseBody.PaymentError = sendPaymentResponse.PaymentError
-	responseBody.PaymentPreimage = &lib.JavaScriptBuffer{Data: sendPaymentResponse.PaymentPreimage}
-	responseBody.PaymentRoute = sendPaymentResponse.PaymentRoute
+	responseBody := &KeySendResponseBody{
+		Amount:          sendPaymentResponse.Invoice.Amount,
+		Fee:             sendPaymentResponse.Invoice.Fee,
+		Description:     sendPaymentResponse.Invoice.Memo,
+		DescriptionHash: sendPaymentResponse.Invoice.DescriptionHash,
+		Destination:     sendPaymentResponse.Invoice.DestinationPubkeyHex,
+		PaymentError:    sendPaymentResponse.PaymentError,
+		PaymentPreimage: sendPaymentResponse.PaymentPreimageStr,
+		PaymentHash:     sendPaymentResponse.PaymentHashStr,
+	}
 
 	return c.JSON(http.StatusOK, responseBody)
 }

--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -29,12 +29,11 @@ type KeySendRequestBody struct {
 }
 
 type KeySendResponseBody struct {
-	Amount          int64  `json:"amount,omitempty"`
-	Fee             int64  `json:"fee,omitempty"`
+	Amount          int64  `json:"amount"`
+	Fee             int64  `json:"fee"`
 	Description     string `json:"description,omitempty"`
 	DescriptionHash string `json:"description_hash,omitempty"`
 	Destination     string `json:"destination,omitempty"`
-	PaymentError    string `json:"payment_error,omitempty"`
 	PaymentPreimage string `json:"payment_preimage,omitempty"`
 	PaymentHash     string `json:"payment_hash,omitempty"`
 }
@@ -112,12 +111,10 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 	}
 
 	responseBody := &KeySendResponseBody{
-		Amount:          sendPaymentResponse.Invoice.Amount,
-		Fee:             sendPaymentResponse.Invoice.Fee,
-		Description:     sendPaymentResponse.Invoice.Memo,
-		DescriptionHash: sendPaymentResponse.Invoice.DescriptionHash,
-		Destination:     sendPaymentResponse.Invoice.DestinationPubkeyHex,
-		PaymentError:    sendPaymentResponse.PaymentError,
+		Amount:          sendPaymentResponse.PaymentRoute.TotalAmt,
+		Fee:             sendPaymentResponse.PaymentRoute.TotalFees,
+		Description:     reqBody.Memo,
+		Destination:     reqBody.Destination,
 		PaymentPreimage: sendPaymentResponse.PaymentPreimageStr,
 		PaymentHash:     sendPaymentResponse.PaymentHashStr,
 	}

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -28,11 +28,10 @@ type PayInvoiceRequestBody struct {
 type PayInvoiceResponseBody struct {
 	PaymentRequest  string `json:"payment_request,omitempty"`
 	Amount          int64  `json:"amount,omitempty"`
-	Fee             int64  `json:"fee,omitempty"`
+	Fee             int64  `json:"fee"`
 	Description     string `json:"description,omitempty"`
 	DescriptionHash string `json:"description_hash,omitempty"`
 	Destination     string `json:"destination,omitempty"`
-	PaymentError    string `json:"payment_error,omitempty"`
 	PaymentPreimage string `json:"payment_preimage,omitempty"`
 	PaymentHash     string `json:"payment_hash,omitempty"`
 }
@@ -120,12 +119,12 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		})
 	}
 	responseBody := &PayInvoiceResponseBody{
-		Amount:          sendPaymentResponse.Invoice.Amount,
-		Fee:             sendPaymentResponse.Invoice.Fee,
-		Description:     sendPaymentResponse.Invoice.Memo,
-		DescriptionHash: sendPaymentResponse.Invoice.DescriptionHash,
-		Destination:     sendPaymentResponse.Invoice.DestinationPubkeyHex,
-		PaymentError:    sendPaymentResponse.PaymentError,
+		PaymentRequest:  paymentRequest,
+		Amount:          sendPaymentResponse.PaymentRoute.TotalAmt,
+		Fee:             sendPaymentResponse.PaymentRoute.TotalFees,
+		Description:     invoice.Memo,
+		DescriptionHash: invoice.DescriptionHash,
+		Destination:     invoice.DestinationPubkeyHex,
 		PaymentPreimage: sendPaymentResponse.PaymentPreimageStr,
 		PaymentHash:     sendPaymentResponse.PaymentHashStr,
 	}

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -1,0 +1,136 @@
+package v2controllers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/getAlby/lndhub.go/lib"
+	"github.com/getAlby/lndhub.go/lib/responses"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/getAlby/lndhub.go/lnd"
+	"github.com/getsentry/sentry-go"
+	sentryecho "github.com/getsentry/sentry-go/echo"
+	"github.com/labstack/echo/v4"
+)
+
+// PayInvoiceController : Pay invoice controller struct
+type PayInvoiceController struct {
+	svc *service.LndhubService
+}
+
+func NewPayInvoiceController(svc *service.LndhubService) *PayInvoiceController {
+	return &PayInvoiceController{svc: svc}
+}
+
+type PayInvoiceRequestBody struct {
+	Invoice string      `json:"invoice" validate:"required"`
+	Amount  interface{} `json:"amount" validate:"omitempty"`
+}
+type PayInvoiceResponseBody struct {
+	RHash              *lib.JavaScriptBuffer `json:"payment_hash,omitempty"`
+	PaymentRequest     string                `json:"payment_request,omitempty"`
+	PayReq             string                `json:"pay_req,omitempty"`
+	Amount             int64                 `json:"num_satoshis,omitempty"`
+	Description        string                `json:"description,omitempty"`
+	DescriptionHashStr string                `json:"description_hash,omitempty"`
+	PaymentError       string                `json:"payment_error,omitempty"`
+	PaymentPreimage    *lib.JavaScriptBuffer `json:"payment_preimage,omitempty"`
+	PaymentRoute       *service.Route        `json:"payment_route,omitempty"`
+}
+
+// PayInvoice godoc
+// @Summary      Pay an invoice
+// @Description  Pay a bolt11 invoice
+// @Accept       json
+// @Produce      json
+// @Tags         Payment
+// @Param        PayInvoiceRequest  body      PayInvoiceRequestBody  True  "Invoice to pay"
+// @Success      200                {object}  PayInvoiceResponseBody
+// @Failure      400                {object}  responses.ErrorResponse
+// @Failure      500                {object}  responses.ErrorResponse
+// @Router       /payinvoice [post]
+// @Security     OAuth2Password
+func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
+	userID := c.Get("UserID").(int64)
+	reqBody := PayInvoiceRequestBody{}
+	if err := c.Bind(&reqBody); err != nil {
+		c.Logger().Errorf("Failed to load payinvoice request body: user_id:%v error: %v", userID, err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	if err := c.Validate(&reqBody); err != nil {
+		c.Logger().Errorf("Invalid payinvoice request body user_id:%v error: %v", userID, err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	paymentRequest := reqBody.Invoice
+	paymentRequest = strings.ToLower(paymentRequest)
+	decodedPaymentRequest, err := controller.svc.DecodePaymentRequest(c.Request().Context(), paymentRequest)
+	if err != nil {
+		c.Logger().Errorf("Invalid payment request user_id:%v error: %v", userID, err)
+		sentry.CaptureException(err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	lnPayReq := &lnd.LNPayReq{
+		PayReq:  decodedPaymentRequest,
+		Keysend: false,
+	}
+	if decodedPaymentRequest.NumSatoshis == 0 {
+		amt, err := controller.svc.ParseInt(reqBody.Amount)
+		if err != nil || amt <= 0 {
+			return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+		}
+		lnPayReq.PayReq.NumSatoshis = amt
+	}
+
+	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, paymentRequest, lnPayReq)
+	if err != nil {
+		return err
+	}
+
+	currentBalance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userID)
+	if err != nil {
+		return err
+	}
+
+	minimumBalance := invoice.Amount
+	if controller.svc.Config.FeeReserve {
+		minimumBalance += invoice.CalcFeeLimit()
+	}
+	if currentBalance < minimumBalance {
+		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)
+		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
+	}
+
+	sendPaymentResponse, err := controller.svc.PayInvoice(c.Request().Context(), invoice)
+	if err != nil {
+		c.Logger().Errorf("Payment failed invoice_id:%v user_id:%v error: %v", invoice.ID, userID, err)
+		if hub := sentryecho.GetHubFromContext(c); hub != nil {
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetExtra("invoice_id", invoice.ID)
+				scope.SetExtra("destination_pubkey_hex", invoice.DestinationPubkeyHex)
+				scope.SetExtra("payment_request", invoice.PaymentRequest)
+				hub.CaptureException(err)
+			})
+		}
+		return c.JSON(http.StatusBadRequest, echo.Map{
+			"error":   true,
+			"code":    10,
+			"message": fmt.Sprintf("Payment failed. Does the receiver have enough inbound capacity? (%v)", err),
+		})
+	}
+	responseBody := &PayInvoiceResponseBody{}
+	responseBody.RHash = &lib.JavaScriptBuffer{Data: sendPaymentResponse.PaymentHash}
+	responseBody.PaymentRequest = paymentRequest
+	responseBody.PayReq = paymentRequest
+	responseBody.Amount = invoice.Amount
+	responseBody.Description = invoice.Memo
+	responseBody.DescriptionHashStr = invoice.DescriptionHash
+	responseBody.PaymentError = sendPaymentResponse.PaymentError
+	responseBody.PaymentPreimage = &lib.JavaScriptBuffer{Data: sendPaymentResponse.PaymentPreimage}
+	responseBody.PaymentRoute = sendPaymentResponse.PaymentRoute
+
+	return c.JSON(http.StatusOK, responseBody)
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -246,6 +246,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/v2/invoices/{payment_hash}": {
+            "get": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Retrieve information about a specific invoice by payment hash",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Get a specific invoice",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Payment hash",
+                        "name": "payment_hash",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.Invoice"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/payments/bolt11": {
             "post": {
                 "security": [

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -175,7 +175,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Account"
+                    "Invoice"
                 ],
                 "summary": "Retrieve incoming invoices",
                 "responses": {
@@ -218,7 +218,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Account"
+                    "Invoice"
                 ],
                 "summary": "Retrieve outgoing payments",
                 "responses": {
@@ -261,7 +261,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Account"
+                    "Invoice"
                 ],
                 "summary": "Get a specific invoice",
                 "parameters": [
@@ -490,7 +490,8 @@ const docTemplate = `{
             ],
             "properties": {
                 "amount": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "description": {
                     "type": "string"
@@ -651,9 +652,6 @@ const docTemplate = `{
                 "fee": {
                     "type": "integer"
                 },
-                "payment_error": {
-                    "type": "string"
-                },
                 "payment_hash": {
                     "type": "string"
                 },
@@ -694,9 +692,6 @@ const docTemplate = `{
                 },
                 "fee": {
                     "type": "integer"
-                },
-                "payment_error": {
-                    "type": "string"
                 },
                 "payment_hash": {
                     "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -24,57 +24,6 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/addinvoice": {
-            "post": {
-                "security": [
-                    {
-                        "OAuth2Password": []
-                    }
-                ],
-                "description": "Returns a new bolt11 invoice",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Invoice"
-                ],
-                "summary": "Generate a new invoice",
-                "parameters": [
-                    {
-                        "description": "Add Invoice",
-                        "name": "invoice",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controllers.AddInvoiceRequestBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.AddInvoiceResponseBody"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/auth": {
             "post": {
                 "description": "Exchanges a login + password for a token",
@@ -120,7 +69,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/balance": {
+        "/v2/balance": {
             "get": {
                 "security": [
                     {
@@ -142,7 +91,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.BalanceResponse"
+                            "$ref": "#/definitions/v2controllers.BalanceResponse"
                         }
                     },
                     "400": {
@@ -160,14 +109,14 @@ const docTemplate = `{
                 }
             }
         },
-        "/checkpayment/{payment_hash}": {
-            "get": {
+        "/v2/invoices": {
+            "post": {
                 "security": [
                     {
                         "OAuth2Password": []
                     }
                 ],
-                "description": "Checks if an invoice is paid, can be incoming our outgoing",
+                "description": "Returns a new bolt11 invoice",
                 "consumes": [
                     "application/json"
                 ],
@@ -177,58 +126,15 @@ const docTemplate = `{
                 "tags": [
                     "Invoice"
                 ],
-                "summary": "Check if an invoice is paid",
+                "summary": "Generate a new invoice",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "Payment hash",
-                        "name": "payment_hash",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.CheckPaymentResponseBody"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/create": {
-            "post": {
-                "description": "Create a new account with a login and password",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Account"
-                ],
-                "summary": "Create an account",
-                "parameters": [
-                    {
-                        "description": "Create User",
-                        "name": "account",
+                        "description": "Add Invoice",
+                        "name": "invoice",
                         "in": "body",
+                        "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controllers.CreateUserRequestBody"
+                            "$ref": "#/definitions/v2controllers.AddInvoiceRequestBody"
                         }
                     }
                 ],
@@ -236,7 +142,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.CreateUserResponseBody"
+                            "$ref": "#/definitions/v2controllers.AddInvoiceResponseBody"
                         }
                     },
                     "400": {
@@ -254,90 +160,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/getinfo": {
-            "get": {
-                "security": [
-                    {
-                        "OAuth2Password": []
-                    }
-                ],
-                "description": "Returns info about the backend node powering this LNDhub instance",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Info"
-                ],
-                "summary": "Get info about the Lightning node",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.GetInfoResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/gettxs": {
-            "get": {
-                "security": [
-                    {
-                        "OAuth2Password": []
-                    }
-                ],
-                "description": "Returns a list of outgoing payments for a user",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Account"
-                ],
-                "summary": "Retrieve outgoing payments",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/controllers.OutgoingInvoice"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/getuserinvoices": {
+        "/v2/invoices/incoming": {
             "get": {
                 "security": [
                     {
@@ -361,7 +184,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/controllers.IncomingInvoice"
+                                "$ref": "#/definitions/v2controllers.Invoice"
                             }
                         }
                     },
@@ -380,67 +203,14 @@ const docTemplate = `{
                 }
             }
         },
-        "/invoice/{user_login}": {
-            "post": {
-                "description": "Returns a new bolt11 invoice for a user with given login, without an Authorization Header",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Invoice"
-                ],
-                "summary": "Generate a new invoice",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User Login",
-                        "name": "user_login",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Add Invoice",
-                        "name": "invoice",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controllers.AddInvoiceRequestBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.AddInvoiceResponseBody"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/invoices/stream": {
+        "/v2/invoices/outgoing": {
             "get": {
                 "security": [
                     {
                         "OAuth2Password": []
                     }
                 ],
-                "description": "Websocket: won't work with Swagger web UI. Returns a stream of settled incoming payments.\nA keep-alive message is sent on startup and every 30s.",
+                "description": "Returns a list of outgoing payments for a user",
                 "consumes": [
                     "application/json"
                 ],
@@ -448,31 +218,16 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Invoice"
+                    "Account"
                 ],
-                "summary": "Websocket for incoming payments",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Auth token, retrieved from /auth endpoint",
-                        "name": "token",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Payment hash of earliest invoice. If specified, missing updates starting from this payment will be sent.",
-                        "name": "since_payment_hash",
-                        "in": "query"
-                    }
-                ],
+                "summary": "Retrieve outgoing payments",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/controllers.InvoiceEventWrapper"
+                                "$ref": "#/definitions/v2controllers.Invoice"
                             }
                         }
                     },
@@ -491,58 +246,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/keysend": {
-            "post": {
-                "security": [
-                    {
-                        "OAuth2Password": []
-                    }
-                ],
-                "description": "Pay a node without an invoice using it's public key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Payment"
-                ],
-                "summary": "Make a keysend payment",
-                "parameters": [
-                    {
-                        "description": "Invoice to pay",
-                        "name": "KeySendRequestBody",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controllers.KeySendRequestBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.KeySendResponseBody"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/payinvoice": {
+        "/v2/payments/bolt11": {
             "post": {
                 "security": [
                     {
@@ -567,7 +271,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controllers.PayInvoiceRequestBody"
+                            "$ref": "#/definitions/v2controllers.PayInvoiceRequestBody"
                         }
                     }
                 ],
@@ -575,7 +279,103 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.PayInvoiceResponseBody"
+                            "$ref": "#/definitions/v2controllers.PayInvoiceResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/payments/keysend": {
+            "post": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Pay a node without an invoice using it's public key",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Payment"
+                ],
+                "summary": "Make a keysend payment",
+                "parameters": [
+                    {
+                        "description": "Invoice to pay",
+                        "name": "KeySendRequestBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.KeySendRequestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.KeySendResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/users": {
+            "post": {
+                "description": "Create a new account with a username and password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Create an account",
+                "parameters": [
+                    {
+                        "description": "Create User",
+                        "name": "account",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.CreateUserRequestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.CreateUserResponseBody"
                         }
                     },
                     "400": {
@@ -595,34 +395,6 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "controllers.AddInvoiceRequestBody": {
-            "type": "object",
-            "properties": {
-                "amt": {
-                    "description": "amount in Satoshi"
-                },
-                "description_hash": {
-                    "type": "string"
-                },
-                "memo": {
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.AddInvoiceResponseBody": {
-            "type": "object",
-            "properties": {
-                "pay_req": {
-                    "type": "string"
-                },
-                "payment_request": {
-                    "type": "string"
-                },
-                "r_hash": {
-                    "type": "string"
-                }
-            }
-        },
         "controllers.AuthRequestBody": {
             "type": "object",
             "properties": {
@@ -648,172 +420,91 @@ const docTemplate = `{
                 }
             }
         },
-        "controllers.BalanceResponse": {
+        "responses.ErrorResponse": {
             "type": "object",
             "properties": {
-                "btc": {
-                    "type": "object",
-                    "properties": {
-                        "availableBalance": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            }
-        },
-        "controllers.Chain": {
-            "type": "object",
-            "properties": {
-                "chain": {
-                    "description": "The blockchain the node is on (eg bitcoin, litecoin)",
-                    "type": "string"
+                "code": {
+                    "type": "integer"
                 },
-                "network": {
-                    "description": "The network the node is on (eg regtest, testnet, mainnet)",
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.CheckPaymentResponseBody": {
-            "type": "object",
-            "properties": {
-                "paid": {
+                "error": {
                     "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },
-        "controllers.CreateUserRequestBody": {
+        "v2controllers.AddInvoiceRequestBody": {
+            "type": "object",
+            "required": [
+                "amount"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "description_hash": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.AddInvoiceResponseBody": {
             "type": "object",
             "properties": {
-                "accounttype": {
+                "expires_at": {
                     "type": "string"
                 },
-                "login": {
+                "payment_hash": {
                     "type": "string"
                 },
-                "partnerid": {
+                "payment_request": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.BalanceResponse": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                },
+                "currency": {
                     "type": "string"
                 },
+                "unit": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.CreateUserRequestBody": {
+            "type": "object",
+            "properties": {
                 "password": {
                     "type": "string"
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },
-        "controllers.CreateUserResponseBody": {
+        "v2controllers.CreateUserResponseBody": {
             "type": "object",
             "properties": {
-                "login": {
-                    "type": "string"
-                },
                 "password": {
                     "type": "string"
-                }
-            }
-        },
-        "controllers.Feature": {
-            "type": "object",
-            "properties": {
-                "is_known": {
-                    "type": "boolean"
                 },
-                "is_required": {
-                    "type": "boolean"
-                },
-                "name": {
+                "username": {
                     "type": "string"
                 }
             }
         },
-        "controllers.GetInfoResponse": {
+        "v2controllers.Invoice": {
             "type": "object",
             "properties": {
-                "alias": {
-                    "description": "If applicable, the alias of the current node, e.g. \"bob\"",
-                    "type": "string"
-                },
-                "best_header_timestamp": {
-                    "description": "Timestamp of the block best known to the wallet",
-                    "type": "integer"
-                },
-                "block_hash": {
-                    "description": "The node's current view of the hash of the best block",
-                    "type": "string"
-                },
-                "block_height": {
-                    "description": "The node's current view of the height of the best block",
-                    "type": "integer"
-                },
-                "chains": {
-                    "description": "A list of active chains the node is connected to",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/controllers.Chain"
-                    }
-                },
-                "color": {
-                    "description": "The color of the current node in hex code format",
-                    "type": "string"
-                },
-                "commit_hash": {
-                    "description": "The SHA1 commit hash that the daemon is compiled with.",
-                    "type": "string"
-                },
-                "features": {
-                    "description": "Features that our node has advertised in our init message, node\nannouncements and invoices.",
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/controllers.Feature"
-                    }
-                },
-                "identity_pubkey": {
-                    "description": "The identity pubkey of the current node.",
-                    "type": "string"
-                },
-                "num_active_channels": {
-                    "description": "Number of active channels",
-                    "type": "integer"
-                },
-                "num_inactive_channels": {
-                    "description": "Number of inactive channels",
-                    "type": "integer"
-                },
-                "num_peers": {
-                    "description": "Number of peers",
-                    "type": "integer"
-                },
-                "num_pending_channels": {
-                    "description": "Number of pending channels",
-                    "type": "integer"
-                },
-                "synced_to_chain": {
-                    "description": "Whether the wallet's view is synced to the main chain",
-                    "type": "boolean"
-                },
-                "synced_to_graph": {
-                    "description": "Whether we consider ourselves synced with the public channel graph.",
-                    "type": "boolean"
-                },
-                "testnet": {
-                    "description": "Whether the current node is connected to testnet. This field is\ndeprecated and the network field should be used instead\n\nDeprecated: Do not use.",
-                    "type": "boolean"
-                },
-                "uris": {
-                    "description": "The URIs of the current node.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "version": {
-                    "description": "The version of the LND software that the node is running.",
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.IncomingInvoice": {
-            "type": "object",
-            "properties": {
-                "amt": {
+                "amount": {
                     "type": "integer"
                 },
                 "custom_records": {
@@ -828,43 +519,48 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
-                "expire_time": {
+                "description_hash": {
+                    "type": "string"
+                },
+                "destination": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "fee": {
                     "type": "integer"
                 },
-                "ispaid": {
+                "is_paid": {
                     "type": "boolean"
                 },
                 "keysend": {
                     "type": "boolean"
                 },
-                "pay_req": {
+                "payment_hash": {
                     "type": "string"
                 },
-                "payment_hash": {},
+                "payment_preimage": {
+                    "type": "string"
+                },
                 "payment_request": {
                     "type": "string"
                 },
-                "r_hash": {},
-                "timestamp": {
-                    "type": "integer"
+                "settled_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 },
                 "type": {
                     "type": "string"
                 }
             }
         },
-        "controllers.InvoiceEventWrapper": {
-            "type": "object",
-            "properties": {
-                "invoice": {
-                    "$ref": "#/definitions/controllers.IncomingInvoice"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.KeySendRequestBody": {
+        "v2controllers.KeySendRequestBody": {
             "type": "object",
             "required": [
                 "amount",
@@ -888,9 +584,12 @@ const docTemplate = `{
                 }
             }
         },
-        "controllers.KeySendResponseBody": {
+        "v2controllers.KeySendResponseBody": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "integer"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -900,137 +599,64 @@ const docTemplate = `{
                 "destination": {
                     "type": "string"
                 },
-                "num_satoshis": {
+                "fee": {
                     "type": "integer"
                 },
                 "payment_error": {
                     "type": "string"
                 },
                 "payment_hash": {
-                    "$ref": "#/definitions/lib.JavaScriptBuffer"
+                    "type": "string"
                 },
                 "payment_preimage": {
-                    "$ref": "#/definitions/lib.JavaScriptBuffer"
-                },
-                "payment_route": {
-                    "$ref": "#/definitions/service.Route"
+                    "type": "string"
                 }
             }
         },
-        "controllers.OutgoingInvoice": {
-            "type": "object",
-            "properties": {
-                "custom_records": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "fee": {
-                    "type": "integer"
-                },
-                "keysend": {
-                    "type": "boolean"
-                },
-                "memo": {
-                    "type": "string"
-                },
-                "payment_hash": {},
-                "payment_preimage": {
-                    "type": "string"
-                },
-                "r_hash": {},
-                "timestamp": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "integer"
-                }
-            }
-        },
-        "controllers.PayInvoiceRequestBody": {
+        "v2controllers.PayInvoiceRequestBody": {
             "type": "object",
             "required": [
                 "invoice"
             ],
             "properties": {
-                "amount": {},
+                "amount": {
+                    "type": "integer",
+                    "minimum": 0
+                },
                 "invoice": {
                     "type": "string"
                 }
             }
         },
-        "controllers.PayInvoiceResponseBody": {
+        "v2controllers.PayInvoiceResponseBody": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "integer"
+                },
                 "description": {
                     "type": "string"
                 },
                 "description_hash": {
                     "type": "string"
                 },
-                "num_satoshis": {
-                    "type": "integer"
-                },
-                "pay_req": {
+                "destination": {
                     "type": "string"
+                },
+                "fee": {
+                    "type": "integer"
                 },
                 "payment_error": {
                     "type": "string"
                 },
                 "payment_hash": {
-                    "$ref": "#/definitions/lib.JavaScriptBuffer"
+                    "type": "string"
                 },
                 "payment_preimage": {
-                    "$ref": "#/definitions/lib.JavaScriptBuffer"
+                    "type": "string"
                 },
                 "payment_request": {
                     "type": "string"
-                },
-                "payment_route": {
-                    "$ref": "#/definitions/service.Route"
-                }
-            }
-        },
-        "lib.JavaScriptBuffer": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                }
-            }
-        },
-        "responses.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer"
-                },
-                "error": {
-                    "type": "boolean"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "service.Route": {
-            "type": "object",
-            "properties": {
-                "total_amt": {
-                    "type": "integer"
-                },
-                "total_fees": {
-                    "type": "integer"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -171,7 +171,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Account"
+                    "Invoice"
                 ],
                 "summary": "Retrieve incoming invoices",
                 "responses": {
@@ -214,7 +214,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Account"
+                    "Invoice"
                 ],
                 "summary": "Retrieve outgoing payments",
                 "responses": {
@@ -257,7 +257,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Account"
+                    "Invoice"
                 ],
                 "summary": "Get a specific invoice",
                 "parameters": [
@@ -486,7 +486,8 @@
             ],
             "properties": {
                 "amount": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "description": {
                     "type": "string"
@@ -647,9 +648,6 @@
                 "fee": {
                     "type": "integer"
                 },
-                "payment_error": {
-                    "type": "string"
-                },
                 "payment_hash": {
                     "type": "string"
                 },
@@ -690,9 +688,6 @@
                 },
                 "fee": {
                     "type": "integer"
-                },
-                "payment_error": {
-                    "type": "string"
                 },
                 "payment_hash": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -20,57 +20,6 @@
     },
     "basePath": "/",
     "paths": {
-        "/addinvoice": {
-            "post": {
-                "security": [
-                    {
-                        "OAuth2Password": []
-                    }
-                ],
-                "description": "Returns a new bolt11 invoice",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Invoice"
-                ],
-                "summary": "Generate a new invoice",
-                "parameters": [
-                    {
-                        "description": "Add Invoice",
-                        "name": "invoice",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controllers.AddInvoiceRequestBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.AddInvoiceResponseBody"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/auth": {
             "post": {
                 "description": "Exchanges a login + password for a token",
@@ -116,7 +65,7 @@
                 }
             }
         },
-        "/balance": {
+        "/v2/balance": {
             "get": {
                 "security": [
                     {
@@ -138,7 +87,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.BalanceResponse"
+                            "$ref": "#/definitions/v2controllers.BalanceResponse"
                         }
                     },
                     "400": {
@@ -156,14 +105,14 @@
                 }
             }
         },
-        "/checkpayment/{payment_hash}": {
-            "get": {
+        "/v2/invoices": {
+            "post": {
                 "security": [
                     {
                         "OAuth2Password": []
                     }
                 ],
-                "description": "Checks if an invoice is paid, can be incoming our outgoing",
+                "description": "Returns a new bolt11 invoice",
                 "consumes": [
                     "application/json"
                 ],
@@ -173,58 +122,15 @@
                 "tags": [
                     "Invoice"
                 ],
-                "summary": "Check if an invoice is paid",
+                "summary": "Generate a new invoice",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "Payment hash",
-                        "name": "payment_hash",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.CheckPaymentResponseBody"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/create": {
-            "post": {
-                "description": "Create a new account with a login and password",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Account"
-                ],
-                "summary": "Create an account",
-                "parameters": [
-                    {
-                        "description": "Create User",
-                        "name": "account",
+                        "description": "Add Invoice",
+                        "name": "invoice",
                         "in": "body",
+                        "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controllers.CreateUserRequestBody"
+                            "$ref": "#/definitions/v2controllers.AddInvoiceRequestBody"
                         }
                     }
                 ],
@@ -232,7 +138,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.CreateUserResponseBody"
+                            "$ref": "#/definitions/v2controllers.AddInvoiceResponseBody"
                         }
                     },
                     "400": {
@@ -250,90 +156,7 @@
                 }
             }
         },
-        "/getinfo": {
-            "get": {
-                "security": [
-                    {
-                        "OAuth2Password": []
-                    }
-                ],
-                "description": "Returns info about the backend node powering this LNDhub instance",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Info"
-                ],
-                "summary": "Get info about the Lightning node",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.GetInfoResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/gettxs": {
-            "get": {
-                "security": [
-                    {
-                        "OAuth2Password": []
-                    }
-                ],
-                "description": "Returns a list of outgoing payments for a user",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Account"
-                ],
-                "summary": "Retrieve outgoing payments",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/controllers.OutgoingInvoice"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/getuserinvoices": {
+        "/v2/invoices/incoming": {
             "get": {
                 "security": [
                     {
@@ -357,7 +180,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/controllers.IncomingInvoice"
+                                "$ref": "#/definitions/v2controllers.Invoice"
                             }
                         }
                     },
@@ -376,67 +199,14 @@
                 }
             }
         },
-        "/invoice/{user_login}": {
-            "post": {
-                "description": "Returns a new bolt11 invoice for a user with given login, without an Authorization Header",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Invoice"
-                ],
-                "summary": "Generate a new invoice",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "User Login",
-                        "name": "user_login",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Add Invoice",
-                        "name": "invoice",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controllers.AddInvoiceRequestBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.AddInvoiceResponseBody"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/invoices/stream": {
+        "/v2/invoices/outgoing": {
             "get": {
                 "security": [
                     {
                         "OAuth2Password": []
                     }
                 ],
-                "description": "Websocket: won't work with Swagger web UI. Returns a stream of settled incoming payments.\nA keep-alive message is sent on startup and every 30s.",
+                "description": "Returns a list of outgoing payments for a user",
                 "consumes": [
                     "application/json"
                 ],
@@ -444,31 +214,16 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Invoice"
+                    "Account"
                 ],
-                "summary": "Websocket for incoming payments",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Auth token, retrieved from /auth endpoint",
-                        "name": "token",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Payment hash of earliest invoice. If specified, missing updates starting from this payment will be sent.",
-                        "name": "since_payment_hash",
-                        "in": "query"
-                    }
-                ],
+                "summary": "Retrieve outgoing payments",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/controllers.InvoiceEventWrapper"
+                                "$ref": "#/definitions/v2controllers.Invoice"
                             }
                         }
                     },
@@ -487,58 +242,7 @@
                 }
             }
         },
-        "/keysend": {
-            "post": {
-                "security": [
-                    {
-                        "OAuth2Password": []
-                    }
-                ],
-                "description": "Pay a node without an invoice using it's public key",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Payment"
-                ],
-                "summary": "Make a keysend payment",
-                "parameters": [
-                    {
-                        "description": "Invoice to pay",
-                        "name": "KeySendRequestBody",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/controllers.KeySendRequestBody"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.KeySendResponseBody"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/responses.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/payinvoice": {
+        "/v2/payments/bolt11": {
             "post": {
                 "security": [
                     {
@@ -563,7 +267,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controllers.PayInvoiceRequestBody"
+                            "$ref": "#/definitions/v2controllers.PayInvoiceRequestBody"
                         }
                     }
                 ],
@@ -571,7 +275,103 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.PayInvoiceResponseBody"
+                            "$ref": "#/definitions/v2controllers.PayInvoiceResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/payments/keysend": {
+            "post": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Pay a node without an invoice using it's public key",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Payment"
+                ],
+                "summary": "Make a keysend payment",
+                "parameters": [
+                    {
+                        "description": "Invoice to pay",
+                        "name": "KeySendRequestBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.KeySendRequestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.KeySendResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/users": {
+            "post": {
+                "description": "Create a new account with a username and password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Create an account",
+                "parameters": [
+                    {
+                        "description": "Create User",
+                        "name": "account",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.CreateUserRequestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.CreateUserResponseBody"
                         }
                     },
                     "400": {
@@ -591,34 +391,6 @@
         }
     },
     "definitions": {
-        "controllers.AddInvoiceRequestBody": {
-            "type": "object",
-            "properties": {
-                "amt": {
-                    "description": "amount in Satoshi"
-                },
-                "description_hash": {
-                    "type": "string"
-                },
-                "memo": {
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.AddInvoiceResponseBody": {
-            "type": "object",
-            "properties": {
-                "pay_req": {
-                    "type": "string"
-                },
-                "payment_request": {
-                    "type": "string"
-                },
-                "r_hash": {
-                    "type": "string"
-                }
-            }
-        },
         "controllers.AuthRequestBody": {
             "type": "object",
             "properties": {
@@ -644,172 +416,91 @@
                 }
             }
         },
-        "controllers.BalanceResponse": {
+        "responses.ErrorResponse": {
             "type": "object",
             "properties": {
-                "btc": {
-                    "type": "object",
-                    "properties": {
-                        "availableBalance": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            }
-        },
-        "controllers.Chain": {
-            "type": "object",
-            "properties": {
-                "chain": {
-                    "description": "The blockchain the node is on (eg bitcoin, litecoin)",
-                    "type": "string"
+                "code": {
+                    "type": "integer"
                 },
-                "network": {
-                    "description": "The network the node is on (eg regtest, testnet, mainnet)",
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.CheckPaymentResponseBody": {
-            "type": "object",
-            "properties": {
-                "paid": {
+                "error": {
                     "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },
-        "controllers.CreateUserRequestBody": {
+        "v2controllers.AddInvoiceRequestBody": {
+            "type": "object",
+            "required": [
+                "amount"
+            ],
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "description_hash": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.AddInvoiceResponseBody": {
             "type": "object",
             "properties": {
-                "accounttype": {
+                "expires_at": {
                     "type": "string"
                 },
-                "login": {
+                "payment_hash": {
                     "type": "string"
                 },
-                "partnerid": {
+                "payment_request": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.BalanceResponse": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                },
+                "currency": {
                     "type": "string"
                 },
+                "unit": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.CreateUserRequestBody": {
+            "type": "object",
+            "properties": {
                 "password": {
                     "type": "string"
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },
-        "controllers.CreateUserResponseBody": {
+        "v2controllers.CreateUserResponseBody": {
             "type": "object",
             "properties": {
-                "login": {
-                    "type": "string"
-                },
                 "password": {
                     "type": "string"
-                }
-            }
-        },
-        "controllers.Feature": {
-            "type": "object",
-            "properties": {
-                "is_known": {
-                    "type": "boolean"
                 },
-                "is_required": {
-                    "type": "boolean"
-                },
-                "name": {
+                "username": {
                     "type": "string"
                 }
             }
         },
-        "controllers.GetInfoResponse": {
+        "v2controllers.Invoice": {
             "type": "object",
             "properties": {
-                "alias": {
-                    "description": "If applicable, the alias of the current node, e.g. \"bob\"",
-                    "type": "string"
-                },
-                "best_header_timestamp": {
-                    "description": "Timestamp of the block best known to the wallet",
-                    "type": "integer"
-                },
-                "block_hash": {
-                    "description": "The node's current view of the hash of the best block",
-                    "type": "string"
-                },
-                "block_height": {
-                    "description": "The node's current view of the height of the best block",
-                    "type": "integer"
-                },
-                "chains": {
-                    "description": "A list of active chains the node is connected to",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/controllers.Chain"
-                    }
-                },
-                "color": {
-                    "description": "The color of the current node in hex code format",
-                    "type": "string"
-                },
-                "commit_hash": {
-                    "description": "The SHA1 commit hash that the daemon is compiled with.",
-                    "type": "string"
-                },
-                "features": {
-                    "description": "Features that our node has advertised in our init message, node\nannouncements and invoices.",
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/controllers.Feature"
-                    }
-                },
-                "identity_pubkey": {
-                    "description": "The identity pubkey of the current node.",
-                    "type": "string"
-                },
-                "num_active_channels": {
-                    "description": "Number of active channels",
-                    "type": "integer"
-                },
-                "num_inactive_channels": {
-                    "description": "Number of inactive channels",
-                    "type": "integer"
-                },
-                "num_peers": {
-                    "description": "Number of peers",
-                    "type": "integer"
-                },
-                "num_pending_channels": {
-                    "description": "Number of pending channels",
-                    "type": "integer"
-                },
-                "synced_to_chain": {
-                    "description": "Whether the wallet's view is synced to the main chain",
-                    "type": "boolean"
-                },
-                "synced_to_graph": {
-                    "description": "Whether we consider ourselves synced with the public channel graph.",
-                    "type": "boolean"
-                },
-                "testnet": {
-                    "description": "Whether the current node is connected to testnet. This field is\ndeprecated and the network field should be used instead\n\nDeprecated: Do not use.",
-                    "type": "boolean"
-                },
-                "uris": {
-                    "description": "The URIs of the current node.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "version": {
-                    "description": "The version of the LND software that the node is running.",
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.IncomingInvoice": {
-            "type": "object",
-            "properties": {
-                "amt": {
+                "amount": {
                     "type": "integer"
                 },
                 "custom_records": {
@@ -824,43 +515,48 @@
                 "description": {
                     "type": "string"
                 },
-                "expire_time": {
+                "description_hash": {
+                    "type": "string"
+                },
+                "destination": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "fee": {
                     "type": "integer"
                 },
-                "ispaid": {
+                "is_paid": {
                     "type": "boolean"
                 },
                 "keysend": {
                     "type": "boolean"
                 },
-                "pay_req": {
+                "payment_hash": {
                     "type": "string"
                 },
-                "payment_hash": {},
+                "payment_preimage": {
+                    "type": "string"
+                },
                 "payment_request": {
                     "type": "string"
                 },
-                "r_hash": {},
-                "timestamp": {
-                    "type": "integer"
+                "settled_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 },
                 "type": {
                     "type": "string"
                 }
             }
         },
-        "controllers.InvoiceEventWrapper": {
-            "type": "object",
-            "properties": {
-                "invoice": {
-                    "$ref": "#/definitions/controllers.IncomingInvoice"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.KeySendRequestBody": {
+        "v2controllers.KeySendRequestBody": {
             "type": "object",
             "required": [
                 "amount",
@@ -884,9 +580,12 @@
                 }
             }
         },
-        "controllers.KeySendResponseBody": {
+        "v2controllers.KeySendResponseBody": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "integer"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -896,137 +595,64 @@
                 "destination": {
                     "type": "string"
                 },
-                "num_satoshis": {
+                "fee": {
                     "type": "integer"
                 },
                 "payment_error": {
                     "type": "string"
                 },
                 "payment_hash": {
-                    "$ref": "#/definitions/lib.JavaScriptBuffer"
+                    "type": "string"
                 },
                 "payment_preimage": {
-                    "$ref": "#/definitions/lib.JavaScriptBuffer"
-                },
-                "payment_route": {
-                    "$ref": "#/definitions/service.Route"
+                    "type": "string"
                 }
             }
         },
-        "controllers.OutgoingInvoice": {
-            "type": "object",
-            "properties": {
-                "custom_records": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "fee": {
-                    "type": "integer"
-                },
-                "keysend": {
-                    "type": "boolean"
-                },
-                "memo": {
-                    "type": "string"
-                },
-                "payment_hash": {},
-                "payment_preimage": {
-                    "type": "string"
-                },
-                "r_hash": {},
-                "timestamp": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "integer"
-                }
-            }
-        },
-        "controllers.PayInvoiceRequestBody": {
+        "v2controllers.PayInvoiceRequestBody": {
             "type": "object",
             "required": [
                 "invoice"
             ],
             "properties": {
-                "amount": {},
+                "amount": {
+                    "type": "integer",
+                    "minimum": 0
+                },
                 "invoice": {
                     "type": "string"
                 }
             }
         },
-        "controllers.PayInvoiceResponseBody": {
+        "v2controllers.PayInvoiceResponseBody": {
             "type": "object",
             "properties": {
+                "amount": {
+                    "type": "integer"
+                },
                 "description": {
                     "type": "string"
                 },
                 "description_hash": {
                     "type": "string"
                 },
-                "num_satoshis": {
-                    "type": "integer"
-                },
-                "pay_req": {
+                "destination": {
                     "type": "string"
+                },
+                "fee": {
+                    "type": "integer"
                 },
                 "payment_error": {
                     "type": "string"
                 },
                 "payment_hash": {
-                    "$ref": "#/definitions/lib.JavaScriptBuffer"
+                    "type": "string"
                 },
                 "payment_preimage": {
-                    "$ref": "#/definitions/lib.JavaScriptBuffer"
+                    "type": "string"
                 },
                 "payment_request": {
                     "type": "string"
-                },
-                "payment_route": {
-                    "$ref": "#/definitions/service.Route"
-                }
-            }
-        },
-        "lib.JavaScriptBuffer": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                }
-            }
-        },
-        "responses.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer"
-                },
-                "error": {
-                    "type": "boolean"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "service.Route": {
-            "type": "object",
-            "properties": {
-                "total_amt": {
-                    "type": "integer"
-                },
-                "total_fees": {
-                    "type": "integer"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -242,6 +242,55 @@
                 }
             }
         },
+        "/v2/invoices/{payment_hash}": {
+            "get": {
+                "security": [
+                    {
+                        "OAuth2Password": []
+                    }
+                ],
+                "description": "Retrieve information about a specific invoice by payment hash",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Get a specific invoice",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Payment hash",
+                        "name": "payment_hash",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.Invoice"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/payments/bolt11": {
             "post": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,23 +1,5 @@
 basePath: /
 definitions:
-  controllers.AddInvoiceRequestBody:
-    properties:
-      amt:
-        description: amount in Satoshi
-      description_hash:
-        type: string
-      memo:
-        type: string
-    type: object
-  controllers.AddInvoiceResponseBody:
-    properties:
-      pay_req:
-        type: string
-      payment_request:
-        type: string
-      r_hash:
-        type: string
-    type: object
   controllers.AuthRequestBody:
     properties:
       login:
@@ -34,128 +16,61 @@ definitions:
       refresh_token:
         type: string
     type: object
-  controllers.BalanceResponse:
+  responses.ErrorResponse:
     properties:
-      btc:
-        properties:
-          availableBalance:
-            type: integer
-        type: object
-    type: object
-  controllers.Chain:
-    properties:
-      chain:
-        description: The blockchain the node is on (eg bitcoin, litecoin)
-        type: string
-      network:
-        description: The network the node is on (eg regtest, testnet, mainnet)
-        type: string
-    type: object
-  controllers.CheckPaymentResponseBody:
-    properties:
-      paid:
+      code:
+        type: integer
+      error:
         type: boolean
+      message:
+        type: string
     type: object
-  controllers.CreateUserRequestBody:
+  v2controllers.AddInvoiceRequestBody:
     properties:
-      accounttype:
+      amount:
+        type: integer
+      description:
         type: string
-      login:
+      description_hash:
         type: string
-      partnerid:
+    required:
+    - amount
+    type: object
+  v2controllers.AddInvoiceResponseBody:
+    properties:
+      expires_at:
         type: string
+      payment_hash:
+        type: string
+      payment_request:
+        type: string
+    type: object
+  v2controllers.BalanceResponse:
+    properties:
+      balance:
+        type: integer
+      currency:
+        type: string
+      unit:
+        type: string
+    type: object
+  v2controllers.CreateUserRequestBody:
+    properties:
       password:
         type: string
-    type: object
-  controllers.CreateUserResponseBody:
-    properties:
-      login:
+      username:
         type: string
+    type: object
+  v2controllers.CreateUserResponseBody:
+    properties:
       password:
         type: string
-    type: object
-  controllers.Feature:
-    properties:
-      is_known:
-        type: boolean
-      is_required:
-        type: boolean
-      name:
+      username:
         type: string
     type: object
-  controllers.GetInfoResponse:
+  v2controllers.Invoice:
     properties:
-      alias:
-        description: If applicable, the alias of the current node, e.g. "bob"
-        type: string
-      best_header_timestamp:
-        description: Timestamp of the block best known to the wallet
-        type: integer
-      block_hash:
-        description: The node's current view of the hash of the best block
-        type: string
-      block_height:
-        description: The node's current view of the height of the best block
-        type: integer
-      chains:
-        description: A list of active chains the node is connected to
-        items:
-          $ref: '#/definitions/controllers.Chain'
-        type: array
-      color:
-        description: The color of the current node in hex code format
-        type: string
-      commit_hash:
-        description: The SHA1 commit hash that the daemon is compiled with.
-        type: string
-      features:
-        additionalProperties:
-          $ref: '#/definitions/controllers.Feature'
-        description: |-
-          Features that our node has advertised in our init message, node
-          announcements and invoices.
-        type: object
-      identity_pubkey:
-        description: The identity pubkey of the current node.
-        type: string
-      num_active_channels:
-        description: Number of active channels
-        type: integer
-      num_inactive_channels:
-        description: Number of inactive channels
-        type: integer
-      num_peers:
-        description: Number of peers
-        type: integer
-      num_pending_channels:
-        description: Number of pending channels
-        type: integer
-      synced_to_chain:
-        description: Whether the wallet's view is synced to the main chain
-        type: boolean
-      synced_to_graph:
-        description: Whether we consider ourselves synced with the public channel
-          graph.
-        type: boolean
-      testnet:
-        description: |-
-          Whether the current node is connected to testnet. This field is
-          deprecated and the network field should be used instead
-
-          Deprecated: Do not use.
-        type: boolean
-      uris:
-        description: The URIs of the current node.
-        items:
-          type: string
-        type: array
-      version:
-        description: The version of the LND software that the node is running.
-        type: string
-    type: object
-  controllers.IncomingInvoice:
-    properties:
-      amt:
+      amount:
         type: integer
       custom_records:
         additionalProperties:
@@ -165,31 +80,34 @@ definitions:
         type: object
       description:
         type: string
-      expire_time:
+      description_hash:
+        type: string
+      destination:
+        type: string
+      error_message:
+        type: string
+      expires_at:
+        type: string
+      fee:
         type: integer
-      ispaid:
+      is_paid:
         type: boolean
       keysend:
         type: boolean
-      pay_req:
+      payment_hash:
         type: string
-      payment_hash: {}
+      payment_preimage:
+        type: string
       payment_request:
         type: string
-      r_hash: {}
-      timestamp:
-        type: integer
+      settled_at:
+        type: string
+      status:
+        type: string
       type:
         type: string
     type: object
-  controllers.InvoiceEventWrapper:
-    properties:
-      invoice:
-        $ref: '#/definitions/controllers.IncomingInvoice'
-      type:
-        type: string
-    type: object
-  controllers.KeySendRequestBody:
+  v2controllers.KeySendRequestBody:
     properties:
       amount:
         type: integer
@@ -205,101 +123,55 @@ definitions:
     - amount
     - destination
     type: object
-  controllers.KeySendResponseBody:
+  v2controllers.KeySendResponseBody:
     properties:
+      amount:
+        type: integer
       description:
         type: string
       description_hash:
         type: string
       destination:
         type: string
-      num_satoshis:
+      fee:
         type: integer
       payment_error:
         type: string
       payment_hash:
-        $ref: '#/definitions/lib.JavaScriptBuffer'
-      payment_preimage:
-        $ref: '#/definitions/lib.JavaScriptBuffer'
-      payment_route:
-        $ref: '#/definitions/service.Route'
-    type: object
-  controllers.OutgoingInvoice:
-    properties:
-      custom_records:
-        additionalProperties:
-          items:
-            type: integer
-          type: array
-        type: object
-      fee:
-        type: integer
-      keysend:
-        type: boolean
-      memo:
         type: string
-      payment_hash: {}
       payment_preimage:
         type: string
-      r_hash: {}
-      timestamp:
-        type: integer
-      type:
-        type: string
-      value:
-        type: integer
     type: object
-  controllers.PayInvoiceRequestBody:
+  v2controllers.PayInvoiceRequestBody:
     properties:
-      amount: {}
+      amount:
+        minimum: 0
+        type: integer
       invoice:
         type: string
     required:
     - invoice
     type: object
-  controllers.PayInvoiceResponseBody:
+  v2controllers.PayInvoiceResponseBody:
     properties:
+      amount:
+        type: integer
       description:
         type: string
       description_hash:
         type: string
-      num_satoshis:
-        type: integer
-      pay_req:
+      destination:
         type: string
+      fee:
+        type: integer
       payment_error:
         type: string
       payment_hash:
-        $ref: '#/definitions/lib.JavaScriptBuffer'
+        type: string
       payment_preimage:
-        $ref: '#/definitions/lib.JavaScriptBuffer'
+        type: string
       payment_request:
         type: string
-      payment_route:
-        $ref: '#/definitions/service.Route'
-    type: object
-  lib.JavaScriptBuffer:
-    properties:
-      data:
-        items:
-          type: integer
-        type: array
-    type: object
-  responses.ErrorResponse:
-    properties:
-      code:
-        type: integer
-      error:
-        type: boolean
-      message:
-        type: string
-    type: object
-  service.Route:
-    properties:
-      total_amt:
-        type: integer
-      total_fees:
-        type: integer
     type: object
 info:
   contact:
@@ -314,38 +186,6 @@ info:
   title: LNDhub.go
   version: 0.6.1
 paths:
-  /addinvoice:
-    post:
-      consumes:
-      - application/json
-      description: Returns a new bolt11 invoice
-      parameters:
-      - description: Add Invoice
-        in: body
-        name: invoice
-        required: true
-        schema:
-          $ref: '#/definitions/controllers.AddInvoiceRequestBody'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controllers.AddInvoiceResponseBody'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      security:
-      - OAuth2Password: []
-      summary: Generate a new invoice
-      tags:
-      - Invoice
   /auth:
     post:
       consumes:
@@ -375,7 +215,7 @@ paths:
       summary: Authenticate
       tags:
       - Account
-  /balance:
+  /v2/balance:
     get:
       consumes:
       - application/json
@@ -386,7 +226,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/controllers.BalanceResponse'
+            $ref: '#/definitions/v2controllers.BalanceResponse'
         "400":
           description: Bad Request
           schema:
@@ -400,78 +240,25 @@ paths:
       summary: Retrieve balance
       tags:
       - Account
-  /checkpayment/{payment_hash}:
-    get:
-      consumes:
-      - application/json
-      description: Checks if an invoice is paid, can be incoming our outgoing
-      parameters:
-      - description: Payment hash
-        in: path
-        name: payment_hash
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controllers.CheckPaymentResponseBody'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      security:
-      - OAuth2Password: []
-      summary: Check if an invoice is paid
-      tags:
-      - Invoice
-  /create:
+  /v2/invoices:
     post:
       consumes:
       - application/json
-      description: Create a new account with a login and password
+      description: Returns a new bolt11 invoice
       parameters:
-      - description: Create User
+      - description: Add Invoice
         in: body
-        name: account
+        name: invoice
+        required: true
         schema:
-          $ref: '#/definitions/controllers.CreateUserRequestBody'
+          $ref: '#/definitions/v2controllers.AddInvoiceRequestBody'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/controllers.CreateUserResponseBody'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      summary: Create an account
-      tags:
-      - Account
-  /getinfo:
-    get:
-      consumes:
-      - application/json
-      description: Returns info about the backend node powering this LNDhub instance
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controllers.GetInfoResponse'
+            $ref: '#/definitions/v2controllers.AddInvoiceResponseBody'
         "400":
           description: Bad Request
           schema:
@@ -482,37 +269,10 @@ paths:
             $ref: '#/definitions/responses.ErrorResponse'
       security:
       - OAuth2Password: []
-      summary: Get info about the Lightning node
+      summary: Generate a new invoice
       tags:
-      - Info
-  /gettxs:
-    get:
-      consumes:
-      - application/json
-      description: Returns a list of outgoing payments for a user
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/controllers.OutgoingInvoice'
-            type: array
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      security:
-      - OAuth2Password: []
-      summary: Retrieve outgoing payments
-      tags:
-      - Account
-  /getuserinvoices:
+      - Invoice
+  /v2/invoices/incoming:
     get:
       consumes:
       - application/json
@@ -524,7 +284,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/controllers.IncomingInvoice'
+              $ref: '#/definitions/v2controllers.Invoice'
             type: array
         "400":
           description: Bad Request
@@ -539,60 +299,11 @@ paths:
       summary: Retrieve incoming invoices
       tags:
       - Account
-  /invoice/{user_login}:
-    post:
-      consumes:
-      - application/json
-      description: Returns a new bolt11 invoice for a user with given login, without
-        an Authorization Header
-      parameters:
-      - description: User Login
-        in: path
-        name: user_login
-        required: true
-        type: string
-      - description: Add Invoice
-        in: body
-        name: invoice
-        required: true
-        schema:
-          $ref: '#/definitions/controllers.AddInvoiceRequestBody'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controllers.AddInvoiceResponseBody'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      summary: Generate a new invoice
-      tags:
-      - Invoice
-  /invoices/stream:
+  /v2/invoices/outgoing:
     get:
       consumes:
       - application/json
-      description: |-
-        Websocket: won't work with Swagger web UI. Returns a stream of settled incoming payments.
-        A keep-alive message is sent on startup and every 30s.
-      parameters:
-      - description: Auth token, retrieved from /auth endpoint
-        in: query
-        name: token
-        required: true
-        type: string
-      - description: Payment hash of earliest invoice. If specified, missing updates
-          starting from this payment will be sent.
-        in: query
-        name: since_payment_hash
-        type: string
+      description: Returns a list of outgoing payments for a user
       produces:
       - application/json
       responses:
@@ -600,7 +311,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/controllers.InvoiceEventWrapper'
+              $ref: '#/definitions/v2controllers.Invoice'
             type: array
         "400":
           description: Bad Request
@@ -612,42 +323,10 @@ paths:
             $ref: '#/definitions/responses.ErrorResponse'
       security:
       - OAuth2Password: []
-      summary: Websocket for incoming payments
+      summary: Retrieve outgoing payments
       tags:
-      - Invoice
-  /keysend:
-    post:
-      consumes:
-      - application/json
-      description: Pay a node without an invoice using it's public key
-      parameters:
-      - description: Invoice to pay
-        in: body
-        name: KeySendRequestBody
-        required: true
-        schema:
-          $ref: '#/definitions/controllers.KeySendRequestBody'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/controllers.KeySendResponseBody'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/responses.ErrorResponse'
-      security:
-      - OAuth2Password: []
-      summary: Make a keysend payment
-      tags:
-      - Payment
-  /payinvoice:
+      - Account
+  /v2/payments/bolt11:
     post:
       consumes:
       - application/json
@@ -658,14 +337,14 @@ paths:
         name: PayInvoiceRequest
         required: true
         schema:
-          $ref: '#/definitions/controllers.PayInvoiceRequestBody'
+          $ref: '#/definitions/v2controllers.PayInvoiceRequestBody'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/controllers.PayInvoiceResponseBody'
+            $ref: '#/definitions/v2controllers.PayInvoiceResponseBody'
         "400":
           description: Bad Request
           schema:
@@ -679,6 +358,67 @@ paths:
       summary: Pay an invoice
       tags:
       - Payment
+  /v2/payments/keysend:
+    post:
+      consumes:
+      - application/json
+      description: Pay a node without an invoice using it's public key
+      parameters:
+      - description: Invoice to pay
+        in: body
+        name: KeySendRequestBody
+        required: true
+        schema:
+          $ref: '#/definitions/v2controllers.KeySendRequestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2controllers.KeySendResponseBody'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      security:
+      - OAuth2Password: []
+      summary: Make a keysend payment
+      tags:
+      - Payment
+  /v2/users:
+    post:
+      consumes:
+      - application/json
+      description: Create a new account with a username and password
+      parameters:
+      - description: Create User
+        in: body
+        name: account
+        schema:
+          $ref: '#/definitions/v2controllers.CreateUserRequestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2controllers.CreateUserResponseBody'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      summary: Create an account
+      tags:
+      - Account
 schemes:
 - https
 - http

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -272,6 +272,37 @@ paths:
       summary: Generate a new invoice
       tags:
       - Invoice
+  /v2/invoices/{payment_hash}:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve information about a specific invoice by payment hash
+      parameters:
+      - description: Payment hash
+        in: path
+        name: payment_hash
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2controllers.Invoice'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      security:
+      - OAuth2Password: []
+      summary: Get a specific invoice
+      tags:
+      - Account
   /v2/invoices/incoming:
     get:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -28,6 +28,7 @@ definitions:
   v2controllers.AddInvoiceRequestBody:
     properties:
       amount:
+        minimum: 0
         type: integer
       description:
         type: string
@@ -135,8 +136,6 @@ definitions:
         type: string
       fee:
         type: integer
-      payment_error:
-        type: string
       payment_hash:
         type: string
       payment_preimage:
@@ -164,8 +163,6 @@ definitions:
         type: string
       fee:
         type: integer
-      payment_error:
-        type: string
       payment_hash:
         type: string
       payment_preimage:
@@ -302,7 +299,7 @@ paths:
       - OAuth2Password: []
       summary: Get a specific invoice
       tags:
-      - Account
+      - Invoice
   /v2/invoices/incoming:
     get:
       consumes:
@@ -329,7 +326,7 @@ paths:
       - OAuth2Password: []
       summary: Retrieve incoming invoices
       tags:
-      - Account
+      - Invoice
   /v2/invoices/outgoing:
     get:
       consumes:
@@ -356,7 +353,7 @@ paths:
       - OAuth2Password: []
       summary: Retrieve outgoing payments
       tags:
-      - Account
+      - Invoice
   /v2/payments/bolt11:
     post:
       consumes:

--- a/legacy_endpoints.go
+++ b/legacy_endpoints.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/getAlby/lndhub.go/controllers"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"golang.org/x/time/rate"
+)
+
+func RegisterLegacyEndpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc) {
+	// Public endpoints for account creation and authentication
+	e.POST("/auth", controllers.NewAuthController(svc).Auth)
+	e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
+	e.POST("/invoice/:user_login", controllers.NewInvoiceController(svc).Invoice, middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(svc.Config.DefaultRateLimit))))
+
+	// Secured endpoints which require a Authorization token (JWT)
+	secured.POST("/addinvoice", controllers.NewAddInvoiceController(svc).AddInvoice)
+	securedWithStrictRateLimit.POST("/payinvoice", controllers.NewPayInvoiceController(svc).PayInvoice)
+	secured.GET("/gettxs", controllers.NewGetTXSController(svc).GetTXS)
+	secured.GET("/getuserinvoices", controllers.NewGetTXSController(svc).GetUserInvoices)
+	secured.GET("/checkpayment/:payment_hash", controllers.NewCheckPaymentController(svc).CheckPayment)
+	secured.GET("/balance", controllers.NewBalanceController(svc).Balance)
+	secured.GET("/getinfo", controllers.NewGetInfoController(svc).GetInfo, createCacheClient().Middleware())
+	securedWithStrictRateLimit.POST("/keysend", controllers.NewKeySendController(svc).KeySend)
+
+	// These endpoints are currently not supported and we return a blank response for backwards compatibility
+	blankController := controllers.NewBlankController(svc)
+	secured.GET("/getbtc", blankController.GetBtc)
+	secured.GET("/getpending", blankController.GetPending)
+
+	//Index page endpoints, no Authorization required
+	homeController := controllers.NewHomeController(svc, indexHtml)
+	e.GET("/", homeController.Home, createCacheClient().Middleware())
+	e.GET("/qr", homeController.QR)
+	//workaround, just adding /static would make a request to these resources hit the authorized group
+	e.GET("/static/css/*", echo.WrapHandler(http.FileServer(http.FS(staticContent))))
+	e.GET("/static/img/*", echo.WrapHandler(http.FileServer(http.FS(staticContent))))
+	e.Pre(middleware.Rewrite(map[string]string{
+		"/favicon.ico": "/static/img/favicon.png",
+	}))
+}

--- a/lib/responses/errors.go
+++ b/lib/responses/errors.go
@@ -35,7 +35,7 @@ var BadAuthError = ErrorResponse{
 var NotEnoughBalanceError = ErrorResponse{
 	Error:   true,
 	Code:    2,
-	Message: "not enough balance. Make sure you have at least 1%% reserved for potential fees",
+	Message: "not enough balance. Make sure you have at least 1% reserved for potential fees",
 }
 
 func HTTPErrorHandler(err error, c echo.Context) {

--- a/main.go
+++ b/main.go
@@ -146,38 +146,11 @@ func main() {
 	}
 
 	strictRateLimitMiddleware := createRateLimitMiddleware(c.StrictRateLimit, c.BurstRateLimit)
-	// Public endpoints for account creation and authentication
-	e.POST("/auth", controllers.NewAuthController(svc).Auth)
-	e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
-	e.POST("/invoice/:user_login", controllers.NewInvoiceController(svc).Invoice, middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(c.DefaultRateLimit))))
-
-	// Secured endpoints which require a Authorization token (JWT)
 	secured := e.Group("", tokens.Middleware(c.JWTSecret), middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(c.DefaultRateLimit))))
 	securedWithStrictRateLimit := e.Group("", tokens.Middleware(c.JWTSecret), strictRateLimitMiddleware)
-	secured.POST("/addinvoice", controllers.NewAddInvoiceController(svc).AddInvoice)
-	securedWithStrictRateLimit.POST("/payinvoice", controllers.NewPayInvoiceController(svc).PayInvoice)
-	secured.GET("/gettxs", controllers.NewGetTXSController(svc).GetTXS)
-	secured.GET("/getuserinvoices", controllers.NewGetTXSController(svc).GetUserInvoices)
-	secured.GET("/checkpayment/:payment_hash", controllers.NewCheckPaymentController(svc).CheckPayment)
-	secured.GET("/balance", controllers.NewBalanceController(svc).Balance)
-	secured.GET("/getinfo", controllers.NewGetInfoController(svc).GetInfo, createCacheClient().Middleware())
-	securedWithStrictRateLimit.POST("/keysend", controllers.NewKeySendController(svc).KeySend)
 
-	// These endpoints are currently not supported and we return a blank response for backwards compatibility
-	blankController := controllers.NewBlankController(svc)
-	secured.GET("/getbtc", blankController.GetBtc)
-	secured.GET("/getpending", blankController.GetPending)
-
-	//Index page endpoints, no Authorization required
-	homeController := controllers.NewHomeController(svc, indexHtml)
-	e.GET("/", homeController.Home, createCacheClient().Middleware())
-	e.GET("/qr", homeController.QR)
-	//workaround, just adding /static would make a request to these resources hit the authorized group
-	e.GET("/static/css/*", echo.WrapHandler(http.FileServer(http.FS(staticContent))))
-	e.GET("/static/img/*", echo.WrapHandler(http.FileServer(http.FS(staticContent))))
-	e.Pre(middleware.Rewrite(map[string]string{
-		"/favicon.ico": "/static/img/favicon.png",
-	}))
+	RegisterLegacyEndpoints(svc, e, secured, securedWithStrictRateLimit, strictRateLimitMiddleware)
+	RegisterV2Endpoints(svc, e, secured, securedWithStrictRateLimit, strictRateLimitMiddleware)
 
 	//invoice streaming
 	//Authentication should be done through the query param because this is a websocket

--- a/v2_endpoints.go
+++ b/v2_endpoints.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	v2controllers "github.com/getAlby/lndhub.go/controllers_v2"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/labstack/echo/v4"
+)
+
+func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc) {
+	// TODO: v2 auth endpoint: generalized oauth token generation
+	// e.POST("/auth", controllers.NewAuthController(svc).Auth)
+	e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
+	invoiceCtrl := v2controllers.NewInvoiceController(svc)
+	secured.POST("/v2/invoices", invoiceCtrl.AddInvoice)
+	secured.GET("/v2/invoices/incoming", invoiceCtrl.GetIncomingInvoices)
+	secured.GET("/v2/invoices/outgoing", invoiceCtrl.GetOutgoingInvoices)
+	secured.GET("/v2/invoices/:payment_hash", invoiceCtrl.GetInvoice)
+	securedWithStrictRateLimit.POST("/v2/payments/bolt11", v2controllers.NewPayInvoiceController(svc).PayInvoice)
+	securedWithStrictRateLimit.POST("/v2/payments/keysend", v2controllers.NewKeySendController(svc).KeySend)
+	secured.GET("/v2/balance", v2controllers.NewBalanceController(svc).Balance)
+}


### PR DESCRIPTION
Closes #194 

- Copied over the relevant API methods to a new package.
- Remove all weird request/response types.
- Make API endpoints RESTful.
- Add some more extra fields on some endpoints.
- Removed the swagger documentation of the legacy API, we want new people to be using this API.

Reworking the `/auth` endpoint would be done next week when working on the OAuth feature.

![Schermafbeelding 2022-06-17 om 16 36 37](https://user-images.githubusercontent.com/33457577/174319821-3c395a1d-701d-4636-a9eb-2bf19355a6ea.png)

