### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .env:
 	cp .env_example .env
+
 build:
-	CGO_ENABLED=0 go build -o lndhub main.go
+	CGO_ENABLED=0 go build -o lndhub


### PR DESCRIPTION
After Legacy/v2 endpoints refactoring the old build command fails with:

```
./main.go:152:2: undefined: RegisterLegacyEndpoints
./main.go:153:2: undefined: RegisterV2Endpoints
```