### PR TITLE
Fix version in documentation

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -716,7 +716,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.6.1",
+	Version:          "0.9.0",
 	Host:             "",
 	BasePath:         "/",
 	Schemes:          []string{"https", "http"},

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -16,7 +16,7 @@ const docTemplate = `{
             "email": "hello@getalby.com"
         },
         "license": {
-            "name": "GNU GPL",
+            "name": "GNU GPLv3",
             "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
         },
         "version": "{{.Version}}"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -13,7 +13,7 @@
             "email": "hello@getalby.com"
         },
         "license": {
-            "name": "GNU GPL",
+            "name": "GNU GPLv3",
             "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
         },
         "version": "0.9.0"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16,7 +16,7 @@
             "name": "GNU GPL",
             "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
         },
-        "version": "0.6.1"
+        "version": "0.9.0"
     },
     "basePath": "/",
     "paths": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -181,7 +181,7 @@ info:
     name: GNU GPL
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: LNDhub.go
-  version: 0.6.1
+  version: 0.9.0
 paths:
   /auth:
     post:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -178,7 +178,7 @@ info:
   description: Accounting wrapper for the Lightning Network providing separate accounts
     for end-users.
   license:
-    name: GNU GPL
+    name: GNU GPLv3
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
   title: LNDhub.go
   version: 0.9.0

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var staticContent embed.FS
 // @contact.url    https://getalby.com
 // @contact.email  hello@getalby.com
 
-// @license.name  GNU GPL
+// @license.name  GNU GPLv3
 // @license.url   https://www.gnu.org/licenses/gpl-3.0.en.html
 
 // @BasePath  /

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var indexHtml string
 var staticContent embed.FS
 
 // @title        LNDhub.go
-// @version      0.6.1
+// @version      0.9.0
 // @description  Accounting wrapper for the Lightning Network providing separate accounts for end-users.
 
 // @contact.name   Alby


### PR DESCRIPTION
* There are lot of places where we are stuck at 0.6.1 while the latest version is 0.9.0
* Fix license identifier (GPL -> GPLv3) to make it more obvious which version is being used
