### PR TITLE
introduce config.AllowCustomLogin and config.AllowCustomPassword

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ vim .env # edit your config
 + `WEBHOOK_URL`: Optional. Callback URL for incoming and outgoing payment events, see below.
 + `FEE_RESERVE`: (default: false) Keep fee reserve for each user
 + `ALLOW_ACCOUNT_CREATION`: (default: true) Enable creation of new accounts
++ `ALLOW_CUSTOM_LOGIN`: (default: true) Allow to specify desired login when creating an user
++ `ALLOW_CUSTOM_PASSWORD`: (default: true) Allow to specify desired password when creating an user
 + `MAX_RECEIVE_AMOUNT`: (default: 0 = no limit) Set maximum amount (in satoshi) for which an invoice can be created
 + `MAX_SEND_AMOUNT`: (default: 0 = no limit) Set maximum amount (in satoshi) of an invoice that can be paid
 + `MAX_ACCOUNT_BALANCE`: (default: 0 = no limit) Set maximum balance (in satoshi) for each account

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	WebhookUrl            string `envconfig:"WEBHOOK_URL"`
 	FeeReserve            bool   `envconfig:"FEE_RESERVE" default:"false"`
 	AllowAccountCreation  bool   `envconfig:"ALLOW_ACCOUNT_CREATION" default:"true"`
+	AllowCustomLogin      bool   `envconfig:"ALLOW_CUSTOM_LOGIN" default:"true"`
+	AllowCustomPassword   bool   `envconfig:"ALLOW_CUSTOM_PASSWORD" default:"true"`
 	MaxReceiveAmount      int64  `envconfig:"MAX_RECEIVE_AMOUNT" default:"0"`
 	MaxSendAmount         int64  `envconfig:"MAX_SEND_AMOUNT" default:"0"`
 	MaxAccountBalance     int64  `envconfig:"MAX_ACCOUNT_BALANCE" default:"0"`

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/getAlby/lndhub.go/common"
 	"github.com/getAlby/lndhub.go/db/models"
@@ -11,6 +12,13 @@ import (
 )
 
 func (svc *LndhubService) CreateUser(ctx context.Context, login string, password string) (user *models.User, err error) {
+
+	if !svc.Config.AllowCustomLogin && login != "" {
+		return nil, errors.New("custom login is not allowed")
+	}
+	if !svc.Config.AllowCustomPassword && password != "" {
+		return nil, errors.New("custom password is not allowed")
+	}
 
 	user = &models.User{}
 


### PR DESCRIPTION
These two options enable/disable the possibility to request a particular login/password while creating a new user.

ISTM it's quite dangerous to allow users to specify their own login/password and I'd prefer not having this option for my instance of LndHub.go.

🤔 not sure why the tests fail with `custom login is not allowed`. I tried to do the changes in a way the default behaviour does not change at all, so I am pretty much puzzled about this.