### PR TITLE
Fix/admin api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ vim .env # edit your config
 + `WEBHOOK_URL`: Optional. Callback URL for incoming and outgoing payment events, see below.
 + `FEE_RESERVE`: (default: false) Keep fee reserve for each user
 + `ALLOW_ACCOUNT_CREATION`: (default: true) Enable creation of new accounts
++ `ADMIN_TOKEN`: Only allow account creation requests if they have the header `Authorization: Bearer ADMIN_TOKEN`
 + `MIN_PASSWORD_ENTROPY`: (default: 0 = disable check) Minimum entropy (bits) of a password to be accepted during account creation
 + `MAX_RECEIVE_AMOUNT`: (default: 0 = no limit) Set maximum amount (in satoshi) for which an invoice can be created
 + `MAX_SEND_AMOUNT`: (default: 0 = no limit) Set maximum amount (in satoshi) of an invoice that can be paid

--- a/legacy_endpoints.go
+++ b/legacy_endpoints.go
@@ -10,11 +10,11 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func RegisterLegacyEndpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc) {
+func RegisterLegacyEndpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc, adminMw echo.MiddlewareFunc) {
 	// Public endpoints for account creation and authentication
 	e.POST("/auth", controllers.NewAuthController(svc).Auth)
 	if svc.Config.AllowAccountCreation {
-		e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
+		e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware, adminMw)
 	}
 	e.POST("/invoice/:user_login", controllers.NewInvoiceController(svc).Invoice, middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(svc.Config.DefaultRateLimit))))
 

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	SentryDSN             string `envconfig:"SENTRY_DSN"`
 	LogFilePath           string `envconfig:"LOG_FILE_PATH"`
 	JWTSecret             []byte `envconfig:"JWT_SECRET" required:"true"`
+	AdminToken            string `envconfig:"ADMIN_TOKEN"`
 	JWTRefreshTokenExpiry int    `envconfig:"JWT_REFRESH_EXPIRY" default:"604800"` // in seconds, default 7 days
 	JWTAccessTokenExpiry  int    `envconfig:"JWT_ACCESS_EXPIRY" default:"172800"`  // in seconds, default 2 days
 	LNDAddress            string `envconfig:"LND_ADDRESS" required:"true"`

--- a/lib/tokens/admin.go
+++ b/lib/tokens/admin.go
@@ -1,0 +1,17 @@
+package tokens
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+func AdminTokenMiddleware(token string) echo.MiddlewareFunc {
+	if token == "" {
+		return func(next echo.HandlerFunc) echo.HandlerFunc {
+			return next
+		}
+	}
+	return middleware.KeyAuth(func(auth string, c echo.Context) (bool, error) {
+		return auth == token, nil
+	})
+}

--- a/main.go
+++ b/main.go
@@ -151,8 +151,8 @@ func main() {
 	secured := e.Group("", tokens.Middleware(c.JWTSecret), middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(c.DefaultRateLimit))))
 	securedWithStrictRateLimit := e.Group("", tokens.Middleware(c.JWTSecret), strictRateLimitMiddleware)
 
-	RegisterLegacyEndpoints(svc, e, secured, securedWithStrictRateLimit, strictRateLimitMiddleware)
-	RegisterV2Endpoints(svc, e, secured, securedWithStrictRateLimit, strictRateLimitMiddleware)
+	RegisterLegacyEndpoints(svc, e, secured, securedWithStrictRateLimit, strictRateLimitMiddleware, tokens.AdminTokenMiddleware(c.AdminToken))
+	RegisterV2Endpoints(svc, e, secured, securedWithStrictRateLimit, strictRateLimitMiddleware, tokens.AdminTokenMiddleware(c.AdminToken))
 
 	//invoice streaming
 	//Authentication should be done through the query param because this is a websocket

--- a/v2_endpoints.go
+++ b/v2_endpoints.go
@@ -6,11 +6,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc) {
+func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc, adminMw echo.MiddlewareFunc) {
 	// TODO: v2 auth endpoint: generalized oauth token generation
 	// e.POST("/auth", controllers.NewAuthController(svc).Auth)
 	if svc.Config.AllowAccountCreation {
-		e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware)
+		e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware, adminMw)
 	}
 	invoiceCtrl := v2controllers.NewInvoiceController(svc)
 	secured.POST("/v2/invoices", invoiceCtrl.AddInvoice)


### PR DESCRIPTION
Closes #205 , #163 
Adds a new config option `ADMIN_TOKEN`. When set, you will need this token in order to be able to create new accounts.

`http POST localhost:3000/create Authorization:"Bearer ADMIN_TOKEN"`