### PR TITLE
set fee reserve to 0 if destination is us

### DIFF
--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -82,7 +82,7 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 
 	minimumBalance := invoice.Amount
 	if controller.svc.Config.FeeReserve {
-		minimumBalance += invoice.CalcFeeLimit()
+		minimumBalance += invoice.CalcFeeLimit(controller.svc.IdentityPubkey)
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -92,7 +92,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 
 	minimumBalance := invoice.Amount
 	if controller.svc.Config.FeeReserve {
-		minimumBalance += invoice.CalcFeeLimit()
+		minimumBalance += invoice.CalcFeeLimit(controller.svc.IdentityPubkey)
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)

--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -84,7 +84,7 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 
 	minimumBalance := invoice.Amount
 	if controller.svc.Config.FeeReserve {
-		minimumBalance += invoice.CalcFeeLimit()
+		minimumBalance += invoice.CalcFeeLimit(controller.svc.IdentityPubkey)
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -94,7 +94,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 
 	minimumBalance := invoice.Amount
 	if controller.svc.Config.FeeReserve {
-		minimumBalance += invoice.CalcFeeLimit()
+		minimumBalance += invoice.CalcFeeLimit(controller.svc.IdentityPubkey)
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)

--- a/db/models/invoice.go
+++ b/db/models/invoice.go
@@ -42,7 +42,10 @@ func (i *Invoice) BeforeAppendModel(ctx context.Context, query bun.Query) error 
 	return nil
 }
 
-func (i *Invoice) CalcFeeLimit() int64 {
+func (i *Invoice) CalcFeeLimit(identityPubkey string) int64 {
+	if i.DestinationPubkeyHex == identityPubkey {
+		return 0
+	}
 	limit := int64(10)
 	if i.Amount > 1000 {
 		limit = int64(math.Ceil(float64(i.Amount)*float64(0.01)) + 1)

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -145,7 +145,8 @@ func (svc *LndhubService) SendPaymentSync(ctx context.Context, invoice *models.I
 func createLnRpcSendRequest(invoice *models.Invoice) (*lnrpc.SendRequest, error) {
 	feeLimit := lnrpc.FeeLimit{
 		Limit: &lnrpc.FeeLimit_Fixed{
-			Fixed: invoice.CalcFeeLimit(),
+			//if we get here, the destination is never ourselves, so we can use a dummy
+			Fixed: invoice.CalcFeeLimit("dummy"),
 		},
 	}
 

--- a/lib/service/invoices_test.go
+++ b/lib/service/invoices_test.go
@@ -12,7 +12,7 @@ func TestCalcFeeWithInvoiceLessThan1000(t *testing.T) {
 		Amount: 500,
 	}
 
-	feeLimit := invoice.CalcFeeLimit()
+	feeLimit := invoice.CalcFeeLimit("dummy")
 	expectedFee := int64(10)
 	assert.Equal(t, expectedFee, feeLimit)
 }
@@ -22,7 +22,7 @@ func TestCalcFeeWithInvoiceEqualTo1000(t *testing.T) {
 		Amount: 500,
 	}
 
-	feeLimit := invoice.CalcFeeLimit()
+	feeLimit := invoice.CalcFeeLimit("dummy")
 	expectedFee := int64(10)
 	assert.Equal(t, expectedFee, feeLimit)
 }
@@ -32,7 +32,7 @@ func TestCalcFeeWithInvoiceMoreThan1000(t *testing.T) {
 		Amount: 1500,
 	}
 
-	feeLimit := invoice.CalcFeeLimit()
+	feeLimit := invoice.CalcFeeLimit("dummy")
 	// 1500 * 0.01 + 1
 	expectedFee := int64(16)
 	assert.Equal(t, expectedFee, feeLimit)


### PR DESCRIPTION
Closes #233 
In case of an internal payment, the fee reserve should be 0.
This change allow clients to create a "Drain account" UX by combining different calls:
- make a payment (or more than 1) leaving just the fee reserve in the account, using a Lightning Address or 0 amount invoice.
- send the rest of the funds to some internal wallet (eg. hello@getalby.com or someone else).