### PR TITLE
delete invoices when balance check fails

### DIFF
--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -87,6 +87,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 
 	currentBalance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userID)
 	if err != nil {
+		controller.svc.DB.NewDelete().Model(&invoice).Where("id = ?", invoice.ID).Exec(c.Request().Context())
 		return err
 	}
 
@@ -96,6 +97,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)
+		controller.svc.DB.NewDelete().Model(&invoice).Where("id = ?", invoice.ID).Exec(c.Request().Context())
 		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
 	}
 

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -89,6 +89,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 
 	currentBalance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userID)
 	if err != nil {
+		controller.svc.DB.NewDelete().Model(&invoice).Where("id = ?", invoice.ID).Exec(c.Request().Context())
 		return err
 	}
 
@@ -98,6 +99,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)
+		controller.svc.DB.NewDelete().Model(&invoice).Where("id = ?", invoice.ID).Exec(c.Request().Context())
 		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
 	}
 


### PR DESCRIPTION
This prevents polluting the database with invoices that will never be paid.
Makes the process of checking invoices states at startup more efficient, because we won't be checking invoices that LND doesn't know anything about.