### PR TITLE
more accurate http status codes for keysend

### DIFF
--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -70,6 +70,15 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 		}
 	}
 
+	if reqBody.Destination == controller.svc.IdentityPubkey && reqBody.CustomRecords[strconv.Itoa(service.TLV_WALLET_ID)] == "" {
+		return c.JSON(http.StatusBadRequest, &responses.ErrorResponse{
+			Error:          true,
+			Code:           8,
+			Message:        fmt.Sprintf("Internal keysend payments require the custom record %d to be present.", service.TLV_WALLET_ID),
+			HttpStatusCode: 400,
+		})
+	}
+
 	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, "", lnPayReq)
 	if err != nil {
 		return err

--- a/lib/responses/errors.go
+++ b/lib/responses/errors.go
@@ -9,33 +9,38 @@ import (
 )
 
 type ErrorResponse struct {
-	Error   bool   `json:"error"`
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Error          bool   `json:"error"`
+	Code           int    `json:"code"`
+	Message        string `json:"message"`
+	HttpStatusCode int    `json:"-"`
 }
 
 var GeneralServerError = ErrorResponse{
-	Error:   true,
-	Code:    6,
-	Message: "Something went wrong. Please try again later",
+	Error:          true,
+	Code:           6,
+	Message:        "Something went wrong. Please try again later",
+	HttpStatusCode: 500,
 }
 
 var BadArgumentsError = ErrorResponse{
-	Error:   true,
-	Code:    8,
-	Message: "Bad arguments",
+	Error:          true,
+	Code:           8,
+	Message:        "Bad arguments",
+	HttpStatusCode: 400,
 }
 
 var BadAuthError = ErrorResponse{
-	Error:   true,
-	Code:    1,
-	Message: "bad auth",
+	Error:          true,
+	Code:           1,
+	Message:        "bad auth",
+	HttpStatusCode: 401,
 }
 
 var NotEnoughBalanceError = ErrorResponse{
-	Error:   true,
-	Code:    2,
-	Message: "not enough balance. Make sure you have at least 1% reserved for potential fees",
+	Error:          true,
+	Code:           2,
+	Message:        "not enough balance. Make sure you have at least 1% reserved for potential fees",
+	HttpStatusCode: 400,
 }
 
 func HTTPErrorHandler(err error, c echo.Context) {


### PR DESCRIPTION
Fixes #270 
Tested locally. 

```
➜  Alby http POST localhost:3000/v2/payments/keysend < keysend.json Authorization:"Bearer $token"
HTTP/1.1 400 Bad Request
Content-Length: 110
Content-Type: application/json; charset=UTF-8
Date: Mon, 09 Jan 2023 14:02:42 GMT
X-Request-Id: vddq9Yq3JPt5gYj5QSGk91cpcL4NYWye

{
    "code": 8,
    "error": true,
    "message": "Internal keysend payments require the custom record 696969 to be present."
}
```

Other endpoints can also be updated to use the status code from `ErrorResponse` to improve the accuracy of the http status code returned. However this should be for another PR.