### PR TITLE
add tx entry tuple constraint

### DIFF
--- a/db/migrations/20230113103000_tx_entry_unique_constraint.up.sql
+++ b/db/migrations/20230113103000_tx_entry_unique_constraint.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transaction_entries ADD CONSTRAINT unique_tuple UNIQUE(user_id, invoice_id, debit_account_id, credit_account_id);

--- a/db/migrations/20230113103000_tx_entry_unique_constraint.up.sql
+++ b/db/migrations/20230113103000_tx_entry_unique_constraint.up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE transaction_entries ADD CONSTRAINT unique_tuple UNIQUE(user_id, invoice_id, debit_account_id, credit_account_id);
+ALTER TABLE transaction_entries ADD CONSTRAINT unique_tx_entry_tuple UNIQUE(user_id, invoice_id, debit_account_id, credit_account_id);


### PR DESCRIPTION
Fixes #155 

Reproducing the bug: https://www.loom.com/share/a45b23b389b847c4a83ae34edb1ab299
Note that this doesn't really solve an issue with the database connection between the 2 db transactions in `HandleFailedPayment`, for that we need to implement #286 . But this would prevent inconsitent data in the db.
