### PR TITLE
Feature/graceful shutdown

### DIFF
--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -115,8 +115,12 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	assert.Equal(suite.T(), common.InvoiceStateInitialized, inv.State)
 
 	//start payment checking loop
-	err = suite.service.CheckAllPendingOutgoingPayments(context.Background())
-	assert.NoError(suite.T(), err)
+	go func() {
+		err = suite.service.CheckAllPendingOutgoingPayments(context.Background())
+		assert.NoError(suite.T(), err)
+	}()
+	//wait a bit for routine to start
+	time.Sleep(time.Second)
 	//send cancel invoice with lnrpc.payment
 	suite.hodlLND.SettlePayment(lnrpc.Payment{
 		PaymentHash:     hex.EncodeToString(invoice.RHash),
@@ -177,8 +181,12 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.InvoiceStateInitialized, inv.State)
 	//start payment checking loop
-	err = suite.service.CheckAllPendingOutgoingPayments(context.Background())
-	assert.NoError(suite.T(), err)
+	go func() {
+		err = suite.service.CheckAllPendingOutgoingPayments(context.Background())
+		assert.NoError(suite.T(), err)
+	}()
+	//wait a bit for routine to start
+	time.Sleep(time.Second)
 	//send settle invoice with lnrpc.payment
 	suite.hodlLND.SettlePayment(lnrpc.Payment{
 		PaymentHash:     hex.EncodeToString(invoice.RHash),

--- a/lib/service/grpc_server.go
+++ b/lib/service/grpc_server.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
-	"net"
 
 	"github.com/getAlby/lndhub.go/common"
 	"github.com/getAlby/lndhub.go/db/models"
@@ -13,21 +11,14 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func (svc *LndhubService) StartGrpcServer(ctx context.Context) {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", svc.Config.GRPCPort))
-	if err != nil {
-		svc.Logger.Fatalf("Failed to start grpc server: %v", err)
-	}
+func (svc *LndhubService) NewGrpcServer(ctx context.Context) *grpc.Server {
 	s := grpc.NewServer()
 	grpcServer, err := NewGrpcServer(svc, ctx)
 	if err != nil {
 		svc.Logger.Fatalf("Failed to init grpc server, %s", err.Error())
 	}
 	lndhubrpc.RegisterInvoiceSubscriptionServer(s, grpcServer)
-	svc.Logger.Infof("gRPC server started at %v", lis.Addr())
-	if err := s.Serve(lis); err != nil {
-		svc.Logger.Fatalf("failed to serve: %v", err)
-	}
+	return s
 }
 
 // server is used to implement helloworld.GreeterServer.

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -243,11 +243,6 @@ func (svc *LndhubService) InvoiceUpdateSubscription(ctx context.Context) error {
 			if err != nil {
 				svc.Logger.Errorf("Error processing invoice update subscription: %v", err)
 				sentry.CaptureException(err)
-				// TODO: close the stream somehoe before retrying?
-				// Wait 30 seconds and try to reconnect
-				// TODO: implement some backoff
-				time.Sleep(30 * time.Second)
-				invoiceSubscriptionStream, _ = svc.ConnectInvoiceSubscription(ctx)
 				continue
 			}
 
@@ -256,7 +251,7 @@ func (svc *LndhubService) InvoiceUpdateSubscription(ctx context.Context) error {
 			// Processing open invoices here could cause a race condition:
 			// We could get this notification faster than we finish the AddInvoice call
 			if rawInvoice.State == lnrpc.Invoice_OPEN {
-				svc.Logger.Infof("Invoice state is open. Ignoring update. r_hash:%v", hex.EncodeToString(rawInvoice.RHash))
+				svc.Logger.Debugf("Invoice state is open. Ignoring update. r_hash:%v", hex.EncodeToString(rawInvoice.RHash))
 				continue
 			}
 


### PR DESCRIPTION
Fixes #285 
Based on this [article](https://www.rudderstack.com/blog/implementing-graceful-shutdown-in-go/).

We need to shutdown a maximum of 3 servers:
- The main Echo REST server
- (optional) The Prometheus metrics server
- (optional) The gRPC server
These servers are shut down gracefully by calling some kind of `Stop` or `Shutdown` function from `main.go` after `backgroundCtx` is canceled, which is done when the signal receives an `os.Interupt` (Ctrl-c) signal.

Other than that there are the background routines:
- Incoming invoice gRPC subscription routine
- Payment tracking routines
- Webhook dispatching routines

These are also canceled by canceling the `backgroundCtx` context. The waitgroup waits until all processes are finished before the program is exited.

