### PR TITLE
fix: remove unused index

### DIFF
--- a/db/migrations/20230206203000_remove_obsolete_index.sql
+++ b/db/migrations/20230206203000_remove_obsolete_index.sql
@@ -1,0 +1,3 @@
+--bun:split
+
+DROP INDEX IF EXISTS index_transaction_entries_on_user_id ON transaction_entries(user_id);


### PR DESCRIPTION
### Unused indezes

```
SELECT
  schemaname || '.' || relname AS table,
  indexrelname AS index,
  pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
  idx_scan as index_scans
FROM pg_stat_user_indexes ui
JOIN pg_index i ON ui.indexrelid = i.indexrelid
WHERE NOT indisunique AND idx_scan < 50 AND pg_relation_size(relid) > 5 * 8192
ORDER BY pg_relation_size(i.indexrelid) / nullif(idx_scan, 0) DESC NULLS FIRST,
pg_relation_size(i.indexrelid) DESC;
```

|table|index|index_size|index_scans|
|:----|:----|:----|:----|
|public.transaction_entries|index_transaction_entries_on_user_id|17 MB|0|