### PR TITLE
Invoice subscription: safety improvements

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -18,7 +18,10 @@ func Open(config *service.Config) (*bun.DB, error) {
 	dsn := config.DatabaseUri
 	switch {
 	case strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") || strings.HasPrefix(dsn, "unix://"):
-		dbConn := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
+		dbConn := sql.OpenDB(
+			pgdriver.NewConnector(
+				pgdriver.WithDSN(dsn),
+				pgdriver.WithTimeout(time.Duration(config.DatabaseTimeout)*time.Second)))
 		db = bun.NewDB(dbConn, pgdialect.New())
 		db.SetMaxOpenConns(config.DatabaseMaxConns)
 		db.SetMaxIdleConns(config.DatabaseMaxIdleConns)

--- a/integration_tests/subscription_start_test.go
+++ b/integration_tests/subscription_start_test.go
@@ -125,7 +125,7 @@ func (mock *lndSubscriptionStartMockClient) SubscribeInvoices(ctx context.Contex
 	return mock, nil
 }
 
-//wait forever
+// wait forever
 func (mock *lndSubscriptionStartMockClient) Recv() (*lnrpc.Invoice, error) {
 	select {}
 }

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	DatabaseMaxConns        int     `envconfig:"DATABASE_MAX_CONNS" default:"10"`
 	DatabaseMaxIdleConns    int     `envconfig:"DATABASE_MAX_IDLE_CONNS" default:"5"`
 	DatabaseConnMaxLifetime int     `envconfig:"DATABASE_CONN_MAX_LIFETIME" default:"1800"` // 30 minutes
+	DatabaseTimeout         int     `envconfig:"DATABASE_TIMEOUT" default:"60"`             // 60 seconds
 	SentryDSN               string  `envconfig:"SENTRY_DSN"`
 	SentryTracesSampleRate  float64 `envconfig:"SENTRY_TRACES_SAMPLE_RATE"`
 	LogFilePath             string  `envconfig:"LOG_FILE_PATH"`

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -222,6 +222,8 @@ func (svc *LndhubService) ConnectInvoiceSubscription(ctx context.Context) (lnd.S
 	// IF we found an invoice we use that index to start the subscription
 	if err == nil {
 		invoiceSubscriptionOptions = lnrpc.InvoiceSubscription{AddIndex: invoice.AddIndex - 1} // -1 because we want updates for that invoice already
+	} else {
+		sentry.CaptureException(err)
 	}
 	svc.Logger.Infof("Starting invoice subscription from index: %v", invoiceSubscriptionOptions.AddIndex)
 	return svc.LndClient.SubscribeInvoices(ctx, &invoiceSubscriptionOptions)

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -225,6 +225,7 @@ func (svc *LndhubService) ConnectInvoiceSubscription(ctx context.Context) (lnd.S
 	// and we are at risk of missing paid invoices, so we should not continue
 	// if we just didn't find any unsettled invoices that's allright though
 	if err != nil && err != sql.ErrNoRows {
+		sentry.CaptureException(err)
 		return nil, err
 	}
 	// subtract 1 (read invoiceSubscriptionOptions.Addindex docs)

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -227,6 +227,8 @@ func (svc *LndhubService) ConnectInvoiceSubscription(ctx context.Context) (lnd.S
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}
+	// subtract 1 (read invoiceSubscriptionOptions.Addindex docs)
+	invoiceSubscriptionOptions.AddIndex = invoice.AddIndex - 1
 	svc.Logger.Infof("Starting invoice subscription from index: %v", invoiceSubscriptionOptions.AddIndex)
 	return svc.LndClient.SubscribeInvoices(ctx, &invoiceSubscriptionOptions)
 }

--- a/main.go
+++ b/main.go
@@ -179,8 +179,9 @@ func main() {
 	backgroundWg.Add(1)
 	go func() {
 		err = svc.InvoiceUpdateSubscription(backGroundCtx)
-		if err != nil {
-			svc.Logger.Error(err)
+		if err != nil && err != context.Canceled {
+			// in case of an error in this routine, we want to restart LNDhub
+			svc.Logger.Fatal(err)
 		}
 		svc.Logger.Info("Invoice routine done")
 		backgroundWg.Done()


### PR DESCRIPTION
Fixes #312 , fixes #313 
This PR changes the behaviour of the invoice subscription routine in case of an error:
- If the database call at startup time fails, we return an error which will crash LNDhub and force a restart. 
- If the `Recv()` call fails (probably because LND is down), then we will also force LNDhub to restart, so it can try to reconnect to LND.

 Other than that
- It introduces a database timeout config option, with a default value of 1 minutes (up from 5 seconds)
- It introduces a safety buffer of 14 hours to make sure we absolutely did not miss any invoices which might have been paid while LNDhub was down.