### PR TITLE
Fix/invoice deletion

### DIFF
--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -91,7 +91,7 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 
 	minimumBalance := invoice.Amount
 	if controller.svc.Config.FeeReserve {
-		minimumBalance += invoice.CalcFeeLimit(controller.svc.IdentityPubkey)
+		minimumBalance += controller.svc.CalcFeeLimit(invoice.DestinationPubkeyHex, invoice.Amount)
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)

--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -79,25 +79,18 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 		})
 	}
 
+	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
+		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
+	}
 	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, "", lnPayReq)
 	if err != nil {
 		return err
 	}
-
-	currentBalance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userID)
-	if err != nil {
-		return err
-	}
-
-	minimumBalance := invoice.Amount
-	if controller.svc.Config.FeeReserve {
-		minimumBalance += controller.svc.CalcFeeLimit(invoice.DestinationPubkeyHex, invoice.Amount)
-	}
-	if currentBalance < minimumBalance {
-		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)
-		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
-	}
-
 	invoice.DestinationCustomRecords = map[uint64][]byte{}
 	for key, value := range reqBody.CustomRecords {
 		intKey, err := strconv.Atoi(key)

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -80,27 +80,19 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		}
 	}
 
+	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
+		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
+	}
+
 	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, paymentRequest, lnPayReq)
 	if err != nil {
 		return err
 	}
-
-	currentBalance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userID)
-	if err != nil {
-		controller.svc.DB.NewDelete().Where("id = ?", invoice.ID).Exec(c.Request().Context())
-		return err
-	}
-
-	minimumBalance := invoice.Amount
-	if controller.svc.Config.FeeReserve {
-		minimumBalance += invoice.CalcFeeLimit(controller.svc.IdentityPubkey)
-	}
-	if currentBalance < minimumBalance {
-		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)
-		controller.svc.DB.NewDelete().Model(&invoice).Where("id = ?", invoice.ID).Exec(c.Request().Context())
-		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
-	}
-
 	sendPaymentResponse, err := controller.svc.PayInvoice(c.Request().Context(), invoice)
 	if err != nil {
 		c.Logger().Errorf("Payment failed invoice_id:%v user_id:%v error: %v", invoice.ID, userID, err)

--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -182,7 +182,7 @@ func (controller *KeySendController) SingleKeySend(c echo.Context, reqBody *KeyS
 
 	minimumBalance := invoice.Amount
 	if controller.svc.Config.FeeReserve {
-		minimumBalance += invoice.CalcFeeLimit(controller.svc.IdentityPubkey)
+		minimumBalance += controller.svc.CalcFeeLimit(invoice.DestinationPubkeyHex, invoice.Amount)
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)

--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -170,12 +170,8 @@ func (controller *KeySendController) SingleKeySend(c echo.Context, reqBody *KeyS
 	}
 	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
 	if err != nil {
-		sentry.CaptureException(err)
-		return nil, &responses.ErrorResponse{
-			Error:   true,
-			Code:    10,
-			Message: err.Error(),
-		}
+		controller.svc.Logger.Error(err)
+		return nil, &responses.GeneralServerError
 	}
 	if !ok {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -95,7 +95,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 
 	minimumBalance := invoice.Amount
 	if controller.svc.Config.FeeReserve {
-		minimumBalance += invoice.CalcFeeLimit(controller.svc.IdentityPubkey)
+		minimumBalance += controller.svc.CalcFeeLimit(invoice.DestinationPubkeyHex, invoice.Amount)
 	}
 	if currentBalance < minimumBalance {
 		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -81,19 +81,17 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		}
 		lnPayReq.PayReq.NumSatoshis = amt
 	}
-
-	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, paymentRequest, lnPayReq)
-	if err != nil {
-		return err
-	}
 	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
 	if err != nil {
-		sentry.CaptureException(err)
-		return c.JSON(http.StatusInternalServerError, err)
+		return err
 	}
 	if !ok {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
 		return c.JSON(http.StatusInternalServerError, responses.NotEnoughBalanceError)
+	}
+	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, paymentRequest, lnPayReq)
+	if err != nil {
+		return err
 	}
 	sendPaymentResponse, err := controller.svc.PayInvoice(c.Request().Context(), invoice)
 	if err != nil {

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -86,23 +86,15 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-
-	currentBalance, err := controller.svc.CurrentUserBalance(c.Request().Context(), userID)
+	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
 	if err != nil {
-		controller.svc.DB.NewDelete().Where("id = ?", invoice.ID).Exec(c.Request().Context())
-		return err
+		sentry.CaptureException(err)
+		return c.JSON(http.StatusInternalServerError, err)
 	}
-
-	minimumBalance := invoice.Amount
-	if controller.svc.Config.FeeReserve {
-		minimumBalance += controller.svc.CalcFeeLimit(invoice.DestinationPubkeyHex, invoice.Amount)
+	if !ok {
+		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
+		return c.JSON(http.StatusInternalServerError, responses.NotEnoughBalanceError)
 	}
-	if currentBalance < minimumBalance {
-		c.Logger().Errorf("User does not have enough balance invoice_id:%v user_id:%v balance:%v amount:%v", invoice.ID, userID, currentBalance, invoice.Amount)
-		controller.svc.DB.NewDelete().Model(&invoice).Where("id = ?", invoice.ID).Exec(c.Request().Context())
-		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
-	}
-
 	sendPaymentResponse, err := controller.svc.PayInvoice(c.Request().Context(), invoice)
 	if err != nil {
 		c.Logger().Errorf("Payment failed invoice_id:%v user_id:%v error: %v", invoice.ID, userID, err)

--- a/db/models/invoice.go
+++ b/db/models/invoice.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/uptrace/bun"
@@ -40,17 +39,6 @@ func (i *Invoice) BeforeAppendModel(ctx context.Context, query bun.Query) error 
 		i.UpdatedAt = bun.NullTime{Time: time.Now()}
 	}
 	return nil
-}
-
-func (i *Invoice) CalcFeeLimit(identityPubkey string) int64 {
-	if i.DestinationPubkeyHex == identityPubkey {
-		return 0
-	}
-	limit := int64(10)
-	if i.Amount > 1000 {
-		limit = int64(math.Ceil(float64(i.Amount)*float64(0.01)) + 1)
-	}
-	return limit
 }
 
 var _ bun.BeforeAppendModelHook = (*Invoice)(nil)

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -75,6 +75,7 @@ func (suite *PaymentTestSuite) SetupSuite() {
 	suite.echo.POST("/payinvoice", controllers.NewPayInvoiceController(suite.service).PayInvoice)
 	suite.echo.GET("/gettxs", controllers.NewGetTXSController(suite.service).GetTXS)
 	suite.echo.POST("/keysend", controllers.NewKeySendController(suite.service).KeySend)
+	suite.echo.GET("/checkpayment/:payment_hash", controllers.NewCheckPaymentController(suite.service).CheckPayment)
 }
 
 func (suite *PaymentTestSuite) TearDownSuite() {
@@ -163,6 +164,13 @@ func (suite *PaymentTestSuite) TestInternalPayment() {
 	errorResp := suite.createPayInvoiceReqError(tooMuch.PayReq, suite.aliceToken)
 	assert.Equal(suite.T(), responses.NotEnoughBalanceError.Code, errorResp.Code)
 
+	//make sure that the "too much invoice isn't there"
+	req := httptest.NewRequest(http.MethodGet, "/checkpayment/"+tooMuch.RHash, nil)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.aliceToken))
+	rec := httptest.NewRecorder()
+	suite.echo.ServeHTTP(rec, req)
+	assert.Equal(suite.T(), http.StatusBadRequest, rec.Code)
+
 	transactonEntriesAlice, _ := suite.service.TransactionEntriesFor(context.Background(), aliceId)
 	aliceBalance, _ := suite.service.CurrentUserBalance(context.Background(), aliceId)
 	assert.Equal(suite.T(), 3, len(transactonEntriesAlice))
@@ -181,13 +189,13 @@ func (suite *PaymentTestSuite) TestInternalPayment() {
 	//generate 0 amount invoice
 	zeroAmt := suite.createAddInvoiceReq(0, "integration test internal payment bob 0 amount", suite.bobToken)
 	toPayForZeroAmt := 10
-	rec := httptest.NewRecorder()
+	rec = httptest.NewRecorder()
 	var buf bytes.Buffer
 	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedPayInvoiceRequestBody{
 		Invoice: zeroAmt.PayReq,
 		Amount:  toPayForZeroAmt,
 	}))
-	req := httptest.NewRequest(http.MethodPost, "/payinvoice", &buf)
+	req = httptest.NewRequest(http.MethodPost, "/payinvoice", &buf)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.aliceToken))
 	suite.echo.ServeHTTP(rec, req)

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -164,7 +164,7 @@ func (suite *PaymentTestSuite) TestInternalPayment() {
 	errorResp := suite.createPayInvoiceReqError(tooMuch.PayReq, suite.aliceToken)
 	assert.Equal(suite.T(), responses.NotEnoughBalanceError.Code, errorResp.Code)
 
-	//make sure that the "too much invoice isn't there"
+	//make sure that the "tooMuch" invoice isn't there
 	req := httptest.NewRequest(http.MethodGet, "/checkpayment/"+tooMuch.RHash, nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.aliceToken))
 	rec := httptest.NewRecorder()

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -117,7 +117,7 @@ func (svc *LndhubService) SendInternalPayment(ctx context.Context, invoice *mode
 func (svc *LndhubService) SendPaymentSync(ctx context.Context, invoice *models.Invoice) (SendPaymentResponse, error) {
 	sendPaymentResponse := SendPaymentResponse{}
 
-	sendPaymentRequest, err := createLnRpcSendRequest(invoice)
+	sendPaymentRequest, err := svc.createLnRpcSendRequest(invoice)
 	if err != nil {
 		return sendPaymentResponse, err
 	}
@@ -143,11 +143,11 @@ func (svc *LndhubService) SendPaymentSync(ctx context.Context, invoice *models.I
 	return sendPaymentResponse, nil
 }
 
-func createLnRpcSendRequest(invoice *models.Invoice) (*lnrpc.SendRequest, error) {
+func (svc *LndhubService) createLnRpcSendRequest(invoice *models.Invoice) (*lnrpc.SendRequest, error) {
 	feeLimit := lnrpc.FeeLimit{
 		Limit: &lnrpc.FeeLimit_Fixed{
 			//if we get here, the destination is never ourselves, so we can use a dummy
-			Fixed: invoice.CalcFeeLimit("dummy"),
+			Fixed: svc.CalcFeeLimit("dummy", invoice.Amount),
 		},
 	}
 

--- a/lib/service/invoices_test.go
+++ b/lib/service/invoices_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var svc = &LndhubService{}
+
 func TestCalcFeeWithInvoiceLessThan1000(t *testing.T) {
 	invoice := &models.Invoice{
 		Amount: 500,
 	}
 
-	feeLimit := invoice.CalcFeeLimit("dummy")
+	feeLimit := svc.CalcFeeLimit("dummy", invoice.Amount)
 	expectedFee := int64(10)
 	assert.Equal(t, expectedFee, feeLimit)
 }
@@ -22,7 +24,7 @@ func TestCalcFeeWithInvoiceEqualTo1000(t *testing.T) {
 		Amount: 500,
 	}
 
-	feeLimit := invoice.CalcFeeLimit("dummy")
+	feeLimit := svc.CalcFeeLimit("dummy", invoice.Amount)
 	expectedFee := int64(10)
 	assert.Equal(t, expectedFee, feeLimit)
 }
@@ -32,7 +34,7 @@ func TestCalcFeeWithInvoiceMoreThan1000(t *testing.T) {
 		Amount: 1500,
 	}
 
-	feeLimit := invoice.CalcFeeLimit("dummy")
+	feeLimit := svc.CalcFeeLimit("dummy", invoice.Amount)
 	// 1500 * 0.01 + 1
 	expectedFee := int64(16)
 	assert.Equal(t, expectedFee, feeLimit)

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -103,7 +103,7 @@ func (svc *LndhubService) BalanceCheck(ctx context.Context, lnpayReq *lnd.LNPayR
 	if svc.Config.FeeReserve {
 		minimumBalance += svc.CalcFeeLimit(lnpayReq.PayReq.Destination, lnpayReq.PayReq.NumSatoshis)
 	}
-	return currentBalance > minimumBalance, nil
+	return currentBalance >= minimumBalance, nil
 }
 
 func (svc *LndhubService) CalcFeeLimit(destination string, amount int64) int64 {


### PR DESCRIPTION
Fixes #311 
The issue was that the "delete invoice" call didn't work and this was not noticed because the error wasn't logged.
We reproduced this but the real fix is to postpone the invoice db entry creation until after preliminary checks have taken place (amount, user balance, invoice expiry (todo #315 )).

In order to do this, this PR does the following things:

- Move the duplicated `BalanceCheck` code to the service package
- Move the `CalcFeeLimit` code from the invoice struct to the service struct
- Move the `AddOutgoingInvoice` call in all 4 payment controllers behind the `BalanceCheck` block, which should look the same everywhere.
- Add a test to make sure the invoice isn't there when we try to pay an invoice that we can't afford. You can verify that this test currently fails on main by cherry-picking commit 03a20148322005e952ef4105bbe5635f9edcf104