### PR TITLE
feat: db index for subscriptions query

### DIFF
--- a/db/migrations/2023021603000_invoice_expiresat.sql
+++ b/db/migrations/2023021603000_invoice_expiresat.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS index_invoices_on_expires_at
+    ON invoices (expires_at);


### PR DESCRIPTION
Follow-up for #316 

This query is executed at startup: 

`select * from invoices where 
invoices.settled_at IS NULL AND 
invoices.add_index IS NOT NULL AND
invoices.expires_at >= (now() - interval '14 hours') 
order by invoices.id asc
limit 1 `

This PR adds an index on `expires_at` to speed up this query. I chose this column because it's the most restrictive one and leaves us just with 14 hours of invoice rows that need to be scanned (instead of the whole table). 

Test results from running on `testnet`: 
Speeded up the query from ~6s down to < 10ms.