### PR TITLE
Code coverage with golanci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,9 +16,6 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.17'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,10 +18,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.17'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.29
-          skip-go-installation: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,3 +24,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.29
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,29 @@
+# Docs https://github.com/marketplace/actions/run-golangci-lint
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.29
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,6 +24,3 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.29
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,3 @@
-# Docs https://github.com/marketplace/actions/run-golangci-lint
 name: golangci-lint
 on:
   push:
@@ -10,15 +9,19 @@ on:
   pull_request:
 permissions:
   contents: read
-  pull-requests: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29
-          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,3 +24,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.29
+          skip-go-installation: true

--- a/README.md
+++ b/README.md
@@ -93,6 +93,24 @@ To build an `lndhub` executable, run the following commands:
 make
 ```
 
+### Linting
+
+We run a golangci-lint action in our pipeline to check for static linting issues.
+If you want to run this yourself run the following command.
+
+```bash
+golangci-lint run ./...
+```
+
+To install golangci-lint check [this](https://golangci-lint.run/usage/install/#local-installation) page.
+
+Mac users can use `brew`
+
+```bash
+brew install golangci-lint
+brew upgrade golangci-lint
+```
+
 ### Development LND setup
 
 To run your own local lightning network and LND you can use [Lightning Polar](https://lightningpolar.com/) which helps you to spin up local LND instances.

--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
+
 	"io/ioutil"
 
 	"github.com/lightningnetwork/lnd/lnrpc"

--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
-
 	"io/ioutil"
 
 	"github.com/lightningnetwork/lnd/lnrpc"


### PR DESCRIPTION
Static linting tools have some nice benefits:

* They can potentially cache anti-patterns or even bugs
* They lower the amount of [bikshedding](https://en.wikipedia.org/wiki/Law_of_triviality) between developers and their style preference. Pick one and stick to it.

Having this run on PR's is a good way to see if a regression was introduces with regards to linting rules.