### PR TITLE
prevent EOF loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,6 +205,7 @@ func main() {
 			err = svc.RabbitMQClient.SubscribeToLndInvoices(backGroundCtx, svc.ProcessInvoiceUpdate)
 			if err != nil && err != context.Canceled {
 				// in case of an error in this routine, we want to restart LNDhub
+				sentry.CaptureException(err)
 				svc.Logger.Fatal(err)
 			}
 

--- a/rabbitmq/rabbitmq.go
+++ b/rabbitmq/rabbitmq.go
@@ -198,7 +198,10 @@ func (client *DefaultClient) SubscribeToLndInvoices(ctx context.Context, handler
 		select {
 		case <-ctx.Done():
 			return context.Canceled
-		case delivery := <-deliveryChan:
+		case delivery, ok := <-deliveryChan:
+			if !ok {
+				return fmt.Errorf("Disconnected from RabbitMQ")
+			}
 			var invoice lnrpc.Invoice
 
 			err := json.Unmarshal(delivery.Body, &invoice)


### PR DESCRIPTION
Fixes #345 
In case the connection to RabbitMQ is lost due to networking error or RabbitMQ being down, the channel will be closed and lndhub should be restarted to try and reconnect again.