### PR TITLE
fix: improve rate limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ vim .env # edit your config
 + `HOST`: (default: "localhost:3000") Host the app should listen on
 + `PORT`: (default: 3000) Port the app should listen on
 + `DEFAULT_RATE_LIMIT`: (default: 10) Requests per second rate limit
-+ `STRICT_RATE_LIMIT`: (default: 10) Requests per burst rate limit (e.g. 1 request each 10 seconds)
-+ `BURST_RATE_LIMIT`: (default: 1) Rate limit burst
++ `STRICT_RATE_LIMIT`: (default: 10) Requests per second rate limit for resource-intensive APIs (e.g. sending a payment)
++ `BURST_RATE_LIMIT`: (default: 1) Specifies the maximum number of requests that can pass at the same moment
 + `ENABLE_PROMETHEUS`: (default: false) Enable Prometheus metrics to be exposed
 + `PROMETHEUS_PORT`: (default: 9092) Prometheus port (path: `/metrics`)
 + `WEBHOOK_URL`: Optional. Callback URL for incoming and outgoing payment events, see below.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"time"
 
@@ -312,12 +313,11 @@ func createRateLimitMiddleware(requestsPerSecond int, burst int) echo.Middleware
 			middleware.RateLimiterMemoryStoreConfig{Rate: rate.Limit(requestsPerSecond), Burst: burst},
 		),
 		IdentifierExtractor: func(ctx echo.Context) (string, error) {
-			userId := ctx.Get("UserID").(string)
-			var id string
-			if userId != "" {
-				id = userId
-			} else {
-				id = ctx.RealIP()
+			userId := ctx.Get("UserID")
+			id := ctx.RealIP()
+			if userId != nil {
+				userIdAsInt64 := ctx.Get("UserID").(int64)
+				id = strconv.FormatInt(userIdAsInt64, 10)
 			}
 
 			fmt.Printf("Current ID for rate limiting %v\n", id)

--- a/main.go
+++ b/main.go
@@ -320,8 +320,6 @@ func createRateLimitMiddleware(requestsPerSecond int, burst int) echo.Middleware
 				id = strconv.FormatInt(userIdAsInt64, 10)
 			}
 
-			fmt.Printf("Current ID for rate limiting %v\n", id)
-
 			return id, nil
 		},
 	}


### PR DESCRIPTION
 - Fix docs
 - Remove default rate limit for non-strict endpoints
 - Change strict endpoint rate limiting to requests / second (instead of every X seconds)
 - Rate limit based on user id (if available, instead of IP) ➡️ NWC