### PR TITLE
add user id to logs as json field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/labstack/gommon v0.4.0
 	github.com/lightningnetwork/lnd v0.15.5-beta.rc2
 	github.com/rabbitmq/amqp091-go v1.6.1
+	github.com/rs/zerolog v1.28.0
 	github.com/stretchr/testify v1.8.1
 	github.com/uptrace/bun v1.1.10
 	github.com/uptrace/bun/dialect/pgdialect v1.1.10
@@ -24,7 +25,6 @@ require (
 	github.com/ziflex/lecho/v3 v3.3.0
 	golang.org/x/crypto v0.5.0
 	google.golang.org/grpc v1.52.0
-	google.golang.org/protobuf v1.28.1
 	gopkg.in/DataDog/dd-trace-go.v1 v1.47.0
 	gopkg.in/macaroon.v2 v2.1.0
 )
@@ -131,7 +131,6 @@ require (
 	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rogpeppe/fastuuid v1.2.0 // indirect
-	github.com/rs/zerolog v1.28.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
@@ -175,6 +174,7 @@ require (
 	golang.org/x/term v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/macaroon-bakery.v2 v2.3.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
@@ -190,7 +190,7 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/go-openapi/spec v0.20.8 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
-	github.com/gorilla/websocket v1.5.0
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/labstack/echo-contrib v0.13.1
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/swaggo/echo-swagger v1.3.5

--- a/legacy_endpoints.go
+++ b/legacy_endpoints.go
@@ -10,13 +10,13 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func RegisterLegacyEndpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc, adminMw echo.MiddlewareFunc) {
+func RegisterLegacyEndpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc, adminMw echo.MiddlewareFunc, logMw echo.MiddlewareFunc) {
 	// Public endpoints for account creation and authentication
-	e.POST("/auth", controllers.NewAuthController(svc).Auth)
+	e.POST("/auth", controllers.NewAuthController(svc).Auth, logMw)
 	if svc.Config.AllowAccountCreation {
-		e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware, adminMw)
+		e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware, adminMw, logMw)
 	}
-	e.POST("/invoice/:user_login", controllers.NewInvoiceController(svc).Invoice, middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(svc.Config.DefaultRateLimit))))
+	e.POST("/invoice/:user_login", controllers.NewInvoiceController(svc).Invoice, middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(svc.Config.DefaultRateLimit))), logMw)
 
 	// Secured endpoints which require a Authorization token (JWT)
 	secured.POST("/addinvoice", controllers.NewAddInvoiceController(svc).AddInvoice)

--- a/v2_endpoints.go
+++ b/v2_endpoints.go
@@ -6,11 +6,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc, adminMw echo.MiddlewareFunc) {
+func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, secured *echo.Group, securedWithStrictRateLimit *echo.Group, strictRateLimitMiddleware echo.MiddlewareFunc, adminMw echo.MiddlewareFunc, logMw echo.MiddlewareFunc) {
 	// TODO: v2 auth endpoint: generalized oauth token generation
 	// e.POST("/auth", controllers.NewAuthController(svc).Auth)
 	if svc.Config.AllowAccountCreation {
-		e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware, adminMw)
+		e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware, adminMw, logMw)
 	}
 	invoiceCtrl := v2controllers.NewInvoiceController(svc)
 	keysendCtrl := v2controllers.NewKeySendController(svc)


### PR DESCRIPTION
Replaces #361 

Creates the log middleware with an Enricher and injects it after the JWT middleware.
There is some code duplication because of the secured/unsecured API groups, but all in all I think it's ok.


As an example, when trying to pay a misformed invoice

Log output before (no seperate UserID field):
```
{"level":"error","id":"1ihPmGY73JFRby8AEj7ZHmN6OwiyMclO","time":"2023-05-23T19:34:23+02:00","message":"Invalid payment request user_id:26 error: rpc error: code = Unknown desc = invalid bech32 string length 3"}
{"level":"debug","id":"1ihPmGY73JFRby8AEj7ZHmN6OwiyMclO","remote_ip":"::1","host":"localhost:3000","method":"POST","uri":"/payinvoice","user_agent":"HTTPie/3.2.1","status":400,"referer":"","latency":48.579542,"latency_human":"48.579542ms","bytes_in":"18","bytes_out":"50","time":"2023-05-23T19:34:23+02:00"}
```

Log output after (`UserID` JSON field both in the request log and the error log):
```
{"level":"error","id":"qUX2veARkFzIeojX9s43uuHSSrV0Owhu","UserID":26,"time":"2023-05-23T18:20:19+02:00","message":"Invalid payment request user_id:26 error: rpc error: code = Unknown desc = invalid bech32 string length 3"}
{"level":"debug","id":"qUX2veARkFzIeojX9s43uuHSSrV0Owhu","UserID":26,"remote_ip":"::1","host":"localhost:3000","method":"POST","uri":"/payinvoice","user_agent":"HTTPie/3.2.1","status":400,"referer":"","latency":103.553458,"latency_human":"103.553458ms","bytes_in":"18","bytes_out":"50","time":"2023-05-23T18:20:19+02:00"}
```
