### PR TITLE
Feature/admin update user

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Wrapper for Lightning Network Daemon (lnd) ⚡
 
 It provides separate accounts for end users.
 Live deployment at [ln.getalby.com](https://ln.getalby.com).
+[API documentation](https://ln.getalby.com/swagger/index.html
 
 ### [LndHub](https://github.com/BlueWallet/LndHub) compatible API implemented in Go using relational database backends
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ vim .env # edit your config
 + `WEBHOOK_URL`: Optional. Callback URL for incoming and outgoing payment events, see below.
 + `FEE_RESERVE`: (default: false) Keep fee reserve for each user
 + `ALLOW_ACCOUNT_CREATION`: (default: true) Enable creation of new accounts
-+ `ADMIN_TOKEN`: Only allow account creation requests if they have the header `Authorization: Bearer ADMIN_TOKEN`. Also required for updating users login, password and (de)activation status.
++ `ADMIN_TOKEN`: Only allow account creation requests if they have the header `Authorization: Bearer ADMIN_TOKEN`. Also required for endpoint for updating users login, password and (de)activation status.
 + `MIN_PASSWORD_ENTROPY`: (default: 0 = disable check) Minimum entropy (bits) of a password to be accepted during account creation
 + `MAX_RECEIVE_AMOUNT`: (default: 0 = no limit) Set maximum amount (in satoshi) for which an invoice can be created
 + `MAX_SEND_AMOUNT`: (default: 0 = no limit) Set maximum amount (in satoshi) of an invoice that can be paid

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ vim .env # edit your config
 + `WEBHOOK_URL`: Optional. Callback URL for incoming and outgoing payment events, see below.
 + `FEE_RESERVE`: (default: false) Keep fee reserve for each user
 + `ALLOW_ACCOUNT_CREATION`: (default: true) Enable creation of new accounts
-+ `ADMIN_TOKEN`: Only allow account creation requests if they have the header `Authorization: Bearer ADMIN_TOKEN`
++ `ADMIN_TOKEN`: Only allow account creation requests if they have the header `Authorization: Bearer ADMIN_TOKEN`. Also required for updating users login, password and (de)activation status.
 + `MIN_PASSWORD_ENTROPY`: (default: 0 = disable check) Minimum entropy (bits) of a password to be accepted during account creation
 + `MAX_RECEIVE_AMOUNT`: (default: 0 = no limit) Set maximum amount (in satoshi) for which an invoice can be created
 + `MAX_SEND_AMOUNT`: (default: 0 = no limit) Set maximum amount (in satoshi) of an invoice that can be paid

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Wrapper for Lightning Network Daemon (lnd) ⚡
 
 It provides separate accounts for end users.
 Live deployment at [ln.getalby.com](https://ln.getalby.com).
-[API documentation](https://ln.getalby.com/swagger/index.html
+[API documentation](https://ln.getalby.com/swagger/index.html)
 
 ### [LndHub](https://github.com/BlueWallet/LndHub) compatible API implemented in Go using relational database backends
 

--- a/controllers/auth.ctrl.go
+++ b/controllers/auth.ctrl.go
@@ -68,6 +68,9 @@ func (controller *AuthController) Auth(c echo.Context) error {
 
 	accessToken, refreshToken, err := controller.svc.GenerateToken(c.Request().Context(), body.Login, body.Password, body.RefreshToken)
 	if err != nil {
+		if err.Error() == responses.AccountDeactivatedError.Message {
+			return c.JSON(http.StatusUnauthorized, responses.AccountDeactivatedError)
+		}
 		return c.JSON(http.StatusUnauthorized, responses.BadAuthError)
 	}
 

--- a/controllers_v2/create.ctrl.go
+++ b/controllers_v2/create.ctrl.go
@@ -29,7 +29,7 @@ type CreateUserRequestBody struct {
 
 // CreateUser godoc
 // @Summary      Create an account
-// @Description  Create a new account with a login and password. Requires Authorization header with admin token.
+// @Description  Create a new account with a login and password.
 // @Accept       json
 // @Produce      json
 // @Tags         Account

--- a/controllers_v2/create.ctrl.go
+++ b/controllers_v2/create.ctrl.go
@@ -29,7 +29,7 @@ type CreateUserRequestBody struct {
 
 // CreateUser godoc
 // @Summary      Create an account
-// @Description  Create a new account with a login and password.
+// @Description  Create a new account with a login and password
 // @Accept       json
 // @Produce      json
 // @Tags         Account

--- a/controllers_v2/create.ctrl.go
+++ b/controllers_v2/create.ctrl.go
@@ -29,7 +29,7 @@ type CreateUserRequestBody struct {
 
 // CreateUser godoc
 // @Summary      Create an account
-// @Description  Create a new account with a login and password
+// @Description  Create a new account with a login and password. Requires Authorization header with admin token.
 // @Accept       json
 // @Produce      json
 // @Tags         Account

--- a/controllers_v2/update.ctrl.go
+++ b/controllers_v2/update.ctrl.go
@@ -39,7 +39,7 @@ type UpdateUserRequestBody struct {
 // @Success      200      {object}  UpdateUserResponseBody
 // @Failure      400      {object}  responses.ErrorResponse
 // @Failure      500      {object}  responses.ErrorResponse
-// @Router       /admin/users [put]
+// @Router       /v2/admin/users [put]
 func (controller *UpdateUserController) UpdateUser(c echo.Context) error {
 
 	var body UpdateUserRequestBody

--- a/controllers_v2/update.ctrl.go
+++ b/controllers_v2/update.ctrl.go
@@ -20,13 +20,13 @@ func NewUpdateUserController(svc *service.LndhubService) *UpdateUserController {
 type UpdateUserResponseBody struct {
 	Login       string `json:"login"`
 	Deactivated bool   `json:"deactivated"`
-	ID          int64  `json:"id" validate:"required"`
+	ID          int64  `json:"id"`
 }
 type UpdateUserRequestBody struct {
 	Login       *string `json:"login,omitempty"`
 	Password    *string `json:"password,omitempty"`
 	Deactivated *bool   `json:"deactivated,omitempty"`
-	ID          int64   `json:"id"`
+	ID          int64   `json:"id" validate:"required"`
 }
 
 // UpdateUser godoc

--- a/controllers_v2/update.ctrl.go
+++ b/controllers_v2/update.ctrl.go
@@ -1,0 +1,66 @@
+package v2controllers
+
+import (
+	"net/http"
+
+	"github.com/getAlby/lndhub.go/lib/responses"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/labstack/echo/v4"
+)
+
+// UpdateUserController : Update user controller struct
+type UpdateUserController struct {
+	svc *service.LndhubService
+}
+
+func NewUpdateUserController(svc *service.LndhubService) *UpdateUserController {
+	return &UpdateUserController{svc: svc}
+}
+
+type UpdateUserResponseBody struct {
+	Login       string `json:"login"`
+	Deactivated bool   `json:"deactivated"`
+	ID          int64  `json:"id" validate:"required"`
+}
+type UpdateUserRequestBody struct {
+	Login       *string `json:"login,omitempty"`
+	Password    *string `json:"password,omitempty"`
+	Deactivated *bool   `json:"deactivated,omitempty"`
+	ID          int64   `json:"id"`
+}
+
+// UpdateUser godoc
+// @Summary      Update an account
+// @Description  Update an account with a new a login, password and activation status
+// @Accept       json
+// @Produce      json
+// @Tags         Account
+// @Param        account  body      UpdateUserRequestBody  false  "Update User"
+// @Success      200      {object}  UpdateUserResponseBody
+// @Failure      400      {object}  responses.ErrorResponse
+// @Failure      500      {object}  responses.ErrorResponse
+// @Router       /admin/users [put]
+func (controller *UpdateUserController) UpdateUser(c echo.Context) error {
+
+	var body UpdateUserRequestBody
+
+	if err := c.Bind(&body); err != nil {
+		c.Logger().Errorf("Failed to load update user request body: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+	if err := c.Validate(&body); err != nil {
+		c.Logger().Errorf("Invalid update user request body error: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+	user, err := controller.svc.UpdateUser(c.Request().Context(), body.ID, body.Login, body.Password, body.Deactivated)
+	if err != nil {
+		c.Logger().Errorf("Failed to update user: %v", err)
+		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+	}
+
+	var ResponseBody UpdateUserResponseBody
+	ResponseBody.Login = user.Login
+	ResponseBody.Deactivated = user.Deactivated
+
+	return c.JSON(http.StatusOK, &ResponseBody)
+}

--- a/controllers_v2/update.ctrl.go
+++ b/controllers_v2/update.ctrl.go
@@ -31,7 +31,7 @@ type UpdateUserRequestBody struct {
 
 // UpdateUser godoc
 // @Summary      Update an account
-// @Description  Update an account with a new a login, password and activation status
+// @Description  Update an account with a new a login, password and activation status. Requires Authorization header with admin token.
 // @Accept       json
 // @Produce      json
 // @Tags         Account

--- a/controllers_v2/update.ctrl.go
+++ b/controllers_v2/update.ctrl.go
@@ -61,6 +61,7 @@ func (controller *UpdateUserController) UpdateUser(c echo.Context) error {
 	var ResponseBody UpdateUserResponseBody
 	ResponseBody.Login = user.Login
 	ResponseBody.Deactivated = user.Deactivated
+	ResponseBody.ID = user.ID
 
 	return c.JSON(http.StatusOK, &ResponseBody)
 }

--- a/db/migrations/20230524110000_user_deactivate.up.sql
+++ b/db/migrations/20230524110000_user_deactivate.up.sql
@@ -1,0 +1,1 @@
+alter table users add column deactivated boolean default false;

--- a/db/models/user.go
+++ b/db/models/user.go
@@ -10,14 +10,15 @@ import (
 
 // User : User Model
 type User struct {
-	ID        int64          `bun:",pk,autoincrement"`
-	Email     sql.NullString `bun:",unique"`
-	Login     string         `bun:",unique,notnull"`
-	Password  string         `bun:",notnull"`
-	CreatedAt time.Time      `bun:",nullzero,notnull,default:current_timestamp"`
-	UpdatedAt bun.NullTime
-	Invoices  []*Invoice `bun:"rel:has-many,join:id=user_id"`
-	Accounts  []*Account `bun:"rel:has-many,join:id=user_id"`
+	ID          int64          `bun:",pk,autoincrement"`
+	Email       sql.NullString `bun:",unique"`
+	Login       string         `bun:",unique,notnull"`
+	Password    string         `bun:",notnull"`
+	CreatedAt   time.Time      `bun:",nullzero,notnull,default:current_timestamp"`
+	UpdatedAt   bun.NullTime
+	Invoices    []*Invoice `bun:"rel:has-many,join:id=user_id"`
+	Accounts    []*Account `bun:"rel:has-many,join:id=user_id"`
+	Deactivated bool
 }
 
 func (u *User) BeforeAppendModel(ctx context.Context, query bun.Query) error {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -495,7 +495,7 @@ const docTemplate = `{
         },
         "/v2/users": {
             "post": {
-                "description": "Create a new account with a login and password.",
+                "description": "Create a new account with a login and password",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -71,7 +71,7 @@ const docTemplate = `{
         },
         "/v2/admin/users": {
             "put": {
-                "description": "Update an account with a new a login, password and activation status",
+                "description": "Update an account with a new a login, password and activation status. Requires Authorization header with admin token.",
                 "consumes": [
                     "application/json"
                 ],
@@ -495,7 +495,7 @@ const docTemplate = `{
         },
         "/v2/users": {
             "post": {
-                "description": "Create a new account with a login and password",
+                "description": "Create a new account with a login and password.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -69,6 +69,51 @@ const docTemplate = `{
                 }
             }
         },
+        "/v2/admin/users": {
+            "put": {
+                "description": "Update an account with a new a login, password and activation status",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Update an account",
+                "parameters": [
+                    {
+                        "description": "Update User",
+                        "name": "account",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.UpdateUserRequestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.UpdateUserResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/balance": {
             "get": {
                 "security": [
@@ -536,9 +581,6 @@ const docTemplate = `{
         },
         "v2controllers.AddInvoiceRequestBody": {
             "type": "object",
-            "required": [
-                "amount"
-            ],
             "properties": {
                 "amount": {
                     "type": "integer",
@@ -680,6 +722,12 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "custom_records": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "destination": {
                     "type": "string"
                 },
@@ -693,6 +741,12 @@ const docTemplate = `{
             "properties": {
                 "amount": {
                     "type": "integer"
+                },
+                "custom_records": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "description": {
                     "type": "string"
@@ -787,6 +841,40 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "payment_request": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.UpdateUserRequestBody": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "deactivated": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "login": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.UpdateUserResponseBody": {
+            "type": "object",
+            "properties": {
+                "deactivated": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "login": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -63,7 +63,7 @@
         },
         "/v2/admin/users": {
             "put": {
-                "description": "Update an account with a new a login, password and activation status",
+                "description": "Update an account with a new a login, password and activation status. Requires Authorization header with admin token.",
                 "consumes": [
                     "application/json"
                 ],
@@ -487,7 +487,7 @@
         },
         "/v2/users": {
             "post": {
-                "description": "Create a new account with a login and password",
+                "description": "Create a new account with a login and password.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -61,6 +61,51 @@
                 }
             }
         },
+        "/v2/admin/users": {
+            "put": {
+                "description": "Update an account with a new a login, password and activation status",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Update an account",
+                "parameters": [
+                    {
+                        "description": "Update User",
+                        "name": "account",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.UpdateUserRequestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v2controllers.UpdateUserResponseBody"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/balance": {
             "get": {
                 "security": [
@@ -528,9 +573,6 @@
         },
         "v2controllers.AddInvoiceRequestBody": {
             "type": "object",
-            "required": [
-                "amount"
-            ],
             "properties": {
                 "amount": {
                     "type": "integer",
@@ -672,6 +714,12 @@
                         "type": "string"
                     }
                 },
+                "custom_records": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "destination": {
                     "type": "string"
                 },
@@ -685,6 +733,12 @@
             "properties": {
                 "amount": {
                     "type": "integer"
+                },
+                "custom_records": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "description": {
                     "type": "string"
@@ -779,6 +833,40 @@
                     "type": "string"
                 },
                 "payment_request": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.UpdateUserRequestBody": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "deactivated": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "login": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "v2controllers.UpdateUserResponseBody": {
+            "type": "object",
+            "properties": {
+                "deactivated": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "login": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -487,7 +487,7 @@
         },
         "/v2/users": {
             "post": {
-                "description": "Create a new account with a login and password.",
+                "description": "Create a new account with a login and password",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -535,7 +535,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new account with a login and password.
+      description: Create a new account with a login and password
       parameters:
       - description: Create User
         in: body

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -267,7 +267,8 @@ paths:
     put:
       consumes:
       - application/json
-      description: Update an account with a new a login, password and activation status
+      description: Update an account with a new a login, password and activation status.
+        Requires Authorization header with admin token.
       parameters:
       - description: Update User
         in: body
@@ -534,7 +535,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new account with a login and password
+      description: Create a new account with a login and password.
       parameters:
       - description: Create User
         in: body

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -34,8 +34,6 @@ definitions:
         type: string
       description_hash:
         type: string
-    required:
-    - amount
     type: object
   v2controllers.AddInvoiceResponseBody:
     properties:
@@ -114,6 +112,10 @@ definitions:
     properties:
       amount:
         type: integer
+      custom_records:
+        additionalProperties:
+          type: string
+        type: object
       customRecords:
         additionalProperties:
           type: string
@@ -130,6 +132,10 @@ definitions:
     properties:
       amount:
         type: integer
+      custom_records:
+        additionalProperties:
+          type: string
+        type: object
       description:
         type: string
       description_hash:
@@ -193,6 +199,28 @@ definitions:
       payment_request:
         type: string
     type: object
+  v2controllers.UpdateUserRequestBody:
+    properties:
+      deactivated:
+        type: boolean
+      id:
+        type: integer
+      login:
+        type: string
+      password:
+        type: string
+    required:
+    - id
+    type: object
+  v2controllers.UpdateUserResponseBody:
+    properties:
+      deactivated:
+        type: boolean
+      id:
+        type: integer
+      login:
+        type: string
+    type: object
 info:
   contact:
     email: hello@getalby.com
@@ -233,6 +261,35 @@ paths:
           schema:
             $ref: '#/definitions/responses.ErrorResponse'
       summary: Authenticate
+      tags:
+      - Account
+  /v2/admin/users:
+    put:
+      consumes:
+      - application/json
+      description: Update an account with a new a login, password and activation status
+      parameters:
+      - description: Update User
+        in: body
+        name: account
+        schema:
+          $ref: '#/definitions/v2controllers.UpdateUserRequestBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v2controllers.UpdateUserResponseBody'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      summary: Update an account
       tags:
       - Account
   /v2/balance:

--- a/integration_tests/create_test.go
+++ b/integration_tests/create_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/getAlby/lndhub.go/controllers"
+	v2controllers "github.com/getAlby/lndhub.go/controllers_v2"
 	"github.com/getAlby/lndhub.go/lib"
 	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/service"
@@ -82,6 +83,25 @@ func (suite *CreateUserTestSuite) TestAdminCreate() {
 	rec = httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
+}
+func (suite *CreateUserTestSuite) TestAdminUpdate() {
+	adminToken := "admin_token"
+	e := echo.New()
+	e.HTTPErrorHandler = responses.HTTPErrorHandler
+	e.Validator = &lib.CustomValidator{Validator: validator.New()}
+	controller := controllers.NewCreateUserController(suite.Service)
+	updateController := v2controllers.NewUpdateUserController(suite.Service)
+	e.POST("/create", controller.CreateUser, tokens.AdminTokenMiddleware(adminToken))
+	e.POST("/update", updateController.UpdateUser, tokens.AdminTokenMiddleware(adminToken))
+	req := httptest.NewRequest(http.MethodPost, "/create", bytes.NewReader([]byte{}))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", adminToken))
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	//get login, pw and id
+	//update user with new password, login
+	//check if user can fetch auth token with new login/pw
+	//deactivate user
+	//check that user can no longer fetch an admin token and the correct error message is shown
 }
 
 func (suite *CreateUserTestSuite) TestCreateWithProvidedLoginAndPassword() {

--- a/lib/responses/errors.go
+++ b/lib/responses/errors.go
@@ -64,6 +64,13 @@ var NotEnoughBalanceError = ErrorResponse{
 	HttpStatusCode: 400,
 }
 
+var AccountDeactivatedError = ErrorResponse{
+	Error:          true,
+	Code:           1,
+	Message:        "Account has been suspended. Please contact support for further assistance.",
+	HttpStatusCode: 401,
+}
+
 func HTTPErrorHandler(err error, c echo.Context) {
 	if c.Response().Committed {
 		return

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3,10 +3,12 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/getAlby/lndhub.go/rabbitmq"
 	"strconv"
 
+	"github.com/getAlby/lndhub.go/rabbitmq"
+
 	"github.com/getAlby/lndhub.go/db/models"
+	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/tokens"
 	"github.com/getAlby/lndhub.go/lnd"
 	"github.com/labstack/gommon/random"
@@ -55,6 +57,10 @@ func (svc *LndhubService) GenerateToken(ctx context.Context, login, password, in
 		{
 			return "", "", fmt.Errorf("login and password or refresh token is required")
 		}
+	}
+
+	if user.Deactivated {
+		return "", "", fmt.Errorf(responses.AccountDeactivatedError.Message)
 	}
 
 	accessToken, err = tokens.GenerateAccessToken(svc.Config.JWTSecret, svc.Config.JWTAccessTokenExpiry, &user)

--- a/v2_endpoints.go
+++ b/v2_endpoints.go
@@ -12,6 +12,7 @@ func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, secured *echo
 	if svc.Config.AllowAccountCreation {
 		e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware, adminMw)
 	}
+	e.PUT("/v2/admin/users", v2controllers.NewUpdateUserController(svc).UpdateUser, strictRateLimitMiddleware, adminMw)
 	invoiceCtrl := v2controllers.NewInvoiceController(svc)
 	keysendCtrl := v2controllers.NewKeySendController(svc)
 	secured.POST("/v2/invoices", invoiceCtrl.AddInvoice)

--- a/v2_endpoints.go
+++ b/v2_endpoints.go
@@ -12,7 +12,10 @@ func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, secured *echo
 	if svc.Config.AllowAccountCreation {
 		e.POST("/v2/users", v2controllers.NewCreateUserController(svc).CreateUser, strictRateLimitMiddleware, adminMw)
 	}
-	e.PUT("/v2/admin/users", v2controllers.NewUpdateUserController(svc).UpdateUser, strictRateLimitMiddleware, adminMw)
+	//require admin token for update user endpoint
+	if svc.Config.AdminToken != "" {
+		e.PUT("/v2/admin/users", v2controllers.NewUpdateUserController(svc).UpdateUser, strictRateLimitMiddleware, adminMw)
+	}
 	invoiceCtrl := v2controllers.NewInvoiceController(svc)
 	keysendCtrl := v2controllers.NewKeySendController(svc)
 	secured.POST("/v2/invoices", invoiceCtrl.AddInvoice)


### PR DESCRIPTION
This PR adds an admin endpoint for updating the user, which can be used for updating the login/password or for activating/deactivating the users account. A deactivated user can no longer fetch a new token and gets an error message when they try to do so.

The extension does not show a specific error message from the error response body, but this is what is returned in the response body:

<img width="319" alt="Screenshot 2023-05-24 at 13 02 02" src="https://github.com/getAlby/lndhub.go/assets/33457577/0cc78261-4216-49df-ae63-15f6a1823bef">

