### PR TITLE
don't require incoming invoices to be non-expired

### DIFF
--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -100,11 +100,10 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 		}
 	}
 	// Search for an incoming invoice with the r_hash that is NOT settled in our DB
-	err := svc.DB.NewSelect().Model(&invoice).Where("type = ? AND r_hash = ? AND state <> ? AND expires_at > ?",
+	err := svc.DB.NewSelect().Model(&invoice).Where("type = ? AND r_hash = ? AND state <> ? ",
 		common.InvoiceTypeIncoming,
 		rHashStr,
-		common.InvoiceStateSettled,
-		time.Now()).Limit(1).Scan(ctx)
+		common.InvoiceStateSettled).Limit(1).Scan(ctx)
 	if err != nil {
 		svc.Logger.Infof("Invoice not found. Ignoring. r_hash:%s", rHashStr)
 		return nil


### PR DESCRIPTION
In case of after-the-fact updates of missed invoices (republished on rabbitmq), these must also be updated.