### PR TITLE
reserve fee amount in database

### DIFF
--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -345,12 +345,6 @@ func (svc *LndhubService) HandleSuccessfulPayment(ctx context.Context, invoice *
 		svc.Logger.Errorf("Could not insert revert feeLimit transaction entry user_id:%v invoice_id:%v error %s", invoice.UserID, invoice.ID, err.Error())
 		return err
 	}
-	_, err = tx.NewInsert().Model(&entry).Exec(ctx)
-	if err != nil {
-		sentry.CaptureException(err)
-		svc.Logger.Errorf("Could not insert fee transaction entry user_id:%v invoice_id:%v error %s", invoice.UserID, invoice.ID, err.Error())
-		return err
-	}
 	err = tx.Commit()
 	if err != nil {
 		sentry.CaptureException(err)

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -197,12 +197,16 @@ func (svc *LndhubService) PayInvoice(ctx context.Context, invoice *models.Invoic
 		return nil, err
 	}
 
+	//calculate the fee limit and add it to the provisional transaction entry
+	//in case of a succesful payment, the fee limit amount will be re-credited
+	//in case of a failed payment, this will get reverted anyway.
+	feeLimit := svc.CalcFeeLimit(invoice.DestinationPubkeyHex, invoice.Amount)
 	entry := models.TransactionEntry{
 		UserID:          userId,
 		InvoiceID:       invoice.ID,
 		CreditAccountID: creditAccount.ID,
 		DebitAccountID:  debitAccount.ID,
-		Amount:          invoice.Amount,
+		Amount:          invoice.Amount + feeLimit,
 	}
 
 	// The DB constraints make sure the user actually has enough balance for the transaction

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -261,7 +261,7 @@ func (svc *LndhubService) HandleFailedPayment(ctx context.Context, invoice *mode
 		InvoiceID:       invoice.ID,
 		CreditAccountID: entryToRevert.DebitAccountID,
 		DebitAccountID:  entryToRevert.CreditAccountID,
-		Amount:          invoice.Amount,
+		Amount:          entryToRevert.Amount,
 	}
 	_, err = tx.NewInsert().Model(&entry).Exec(ctx)
 	if err != nil {


### PR DESCRIPTION
This PR adds the maximum fee a user can pay to the amount that is debited from their account.
In case of a succesful payment, this provisional max amount is credited to their balance again.
In case of a failed payment, the transaction entry is reversed anyway, but I had to change this to use the right amount (the one from the entry to reverse, which was the same as the invoice amount up until now, but will be different now).

To do:

- [ ] Add integration test
- [ ] Make demo video about issue & fix