### PR TITLE
Fix/add fee provision 2

### DIFF
--- a/db/migrations/20230703120000_add_tx_entry_type.up.sql
+++ b/db/migrations/20230703120000_add_tx_entry_type.up.sql
@@ -1,3 +1,2 @@
 alter table transaction_entries 
-add column entry_type character varying,
-add column fee_reserve_id bigint;
+add column entry_type character varying;

--- a/db/migrations/20230703120000_add_tx_entry_type.up.sql
+++ b/db/migrations/20230703120000_add_tx_entry_type.up.sql
@@ -1,1 +1,3 @@
-alter table transaction_entries add column entry_type character varying;
+alter table transaction_entries 
+add column entry_type character varying,
+add column fee_reserve_id bigint;

--- a/db/migrations/20230703120000_add_tx_entry_type.up.sql
+++ b/db/migrations/20230703120000_add_tx_entry_type.up.sql
@@ -1,0 +1,1 @@
+alter table transaction_entries add column entry_type character varying;

--- a/db/migrations/20230703130000_replace_tx_entry_constraint.up.sql
+++ b/db/migrations/20230703130000_replace_tx_entry_constraint.up.sql
@@ -1,0 +1,2 @@
+alter table transaction_entries drop constraint unique_tx_entry_tuple,
+add constraint unique_tx_entry_tuple UNIQUE(user_id, invoice_id, debit_account_id, credit_account_id, entry_type);

--- a/db/models/transactionentry.go
+++ b/db/models/transactionentry.go
@@ -23,7 +23,6 @@ type TransactionEntry struct {
 	ParentID        int64             `bun:",nullzero"`
 	Parent          *TransactionEntry `bun:"rel:belongs-to"`
 	CreditAccountID int64             `bun:",notnull"`
-	FeeReserveID    int64             `bun:",nullzero"`
 	FeeReserve      *TransactionEntry `bun:"rel:belongs-to"`
 	CreditAccount   *Account          `bun:"rel:belongs-to,join:credit_account_id=id"`
 	DebitAccountID  int64             `bun:",notnull"`

--- a/db/models/transactionentry.go
+++ b/db/models/transactionentry.go
@@ -4,6 +4,15 @@ import (
 	"time"
 )
 
+const (
+	EntryTypeIncoming           = "incoming"
+	EntryTypeOutgoing           = "outgoing"
+	EntryTypeFee                = "fee"
+	EntryTypeFeeReserve         = "fee_reserve"
+	EntryTypeFeeReserveReversal = "fee_reserve_reversal"
+	EntryTypeOutgoingReversal   = "outgoing_reversal"
+)
+
 // TransactionEntry : Transaction Entries Model
 type TransactionEntry struct {
 	ID              int64             `bun:",pk,autoincrement"`
@@ -19,4 +28,5 @@ type TransactionEntry struct {
 	DebitAccount    *Account          `bun:"rel:belongs-to,join:debit_account_id=id"`
 	Amount          int64             `bun:",notnull"`
 	CreatedAt       time.Time         `bun:",nullzero,notnull,default:current_timestamp"`
+	EntryType       string
 }

--- a/db/models/transactionentry.go
+++ b/db/models/transactionentry.go
@@ -23,6 +23,8 @@ type TransactionEntry struct {
 	ParentID        int64             `bun:",nullzero"`
 	Parent          *TransactionEntry `bun:"rel:belongs-to"`
 	CreditAccountID int64             `bun:",notnull"`
+	FeeReserveID    int64             `bun:",nullzero"`
+	FeeReserve      *TransactionEntry `bun:"rel:belongs-to"`
 	CreditAccount   *Account          `bun:"rel:belongs-to,join:credit_account_id=id"`
 	DebitAccountID  int64             `bun:",notnull"`
 	DebitAccount    *Account          `bun:"rel:belongs-to,join:debit_account_id=id"`

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -34,7 +34,7 @@ type HodlInvoiceSuite struct {
 
 func (suite *HodlInvoiceSuite) SetupSuite() {
 	mlnd := newDefaultMockLND()
-	externalLND, err := NewMockLND("1234567890abcdefabcd", 0, make(chan (*lnrpc.Invoice)))
+	externalLND, err := NewMockLND("1234567890abcdefabcd", 0, make(chan (*lnrpc.Invoice), 5))
 	if err != nil {
 		log.Fatalf("Error initializing test service: %v", err)
 	}
@@ -307,17 +307,11 @@ func (suite *HodlInvoiceSuite) TestNegativeBalanceWithHodl() {
 		Status:          lnrpc.Payment_SUCCEEDED,
 		FailureReason:   0,
 	})
-	//wait a bit for db update to happen
-	time.Sleep(time.Second)
-
-	if err != nil {
-		fmt.Printf("Error when getting balance %v\n", err.Error())
-	}
 	//fetch user balance again
 	userBalance, err := suite.service.CurrentUserBalance(context.Background(), userId)
 	assert.NoError(suite.T(), err)
 	//assert the balance is negative
-	assert.True(suite.T(), userBalance < 0)
+	assert.False(suite.T(), userBalance < 0)
 }
 
 func (suite *HodlInvoiceSuite) TearDownSuite() {

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -310,7 +310,7 @@ func (suite *HodlInvoiceSuite) TestNegativeBalanceWithHodl() {
 	//fetch user balance again
 	userBalance, err := suite.service.CurrentUserBalance(context.Background(), userId)
 	assert.NoError(suite.T(), err)
-	//assert the balance is negative
+	//assert the balance did not go below 0
 	assert.False(suite.T(), userBalance < 0)
 }
 

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -228,6 +228,97 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	clearTable(suite.service, "transaction_entries")
 	clearTable(suite.service, "accounts")
 }
+func (suite *HodlInvoiceSuite) TestNegativeBalanceWithHodl() {
+	//10M funding, 5M sat requested
+	userFundingSats := 10000000
+	externalSatRequested := 5000000
+	userId := getUserIdFromToken(suite.userToken)
+	// fund user account
+	invoiceResponse := suite.createAddInvoiceReq(userFundingSats, "integration test external payment user", suite.userToken)
+	err := suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
+	assert.NoError(suite.T(), err)
+
+	// wait a bit for the callback event to hit
+	time.Sleep(10 * time.Millisecond)
+
+	// create external invoice
+	externalInvoice := lnrpc.Invoice{
+		Memo:      "integration tests: external pay from user",
+		Value:     int64(externalSatRequested),
+		RPreimage: []byte("preimage2"),
+	}
+	invoice, err := suite.externalLND.AddInvoice(context.Background(), &externalInvoice)
+	assert.NoError(suite.T(), err)
+	//the fee should be 1 %, so 50k sats (+1)
+	feeLimit := suite.service.CalcFeeLimit(suite.externalLND.GetMainPubkey(), int64(externalSatRequested))
+	// pay external from user, req will be canceled after 2 sec
+	go suite.createPayInvoiceReqWithCancel(invoice.PaymentRequest, suite.userToken)
+	// wait for payment to be updated as pending in database
+	time.Sleep(3 * time.Second)
+	// check payment is pending
+	inv, err := suite.service.FindInvoiceByPaymentHash(context.Background(), userId, hex.EncodeToString(invoice.RHash))
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), common.InvoiceStateInitialized, inv.State)
+
+	//drain balance from account: at this point we have 5 M, so we can pay 4.95M
+	drainInv := lnrpc.Invoice{
+		Memo:      "integration tests: external pay from user",
+		Value:     int64(4950000),
+		RPreimage: []byte("preimage3"),
+	}
+	drainInvoice, err := suite.externalLND.AddInvoice(context.Background(), &drainInv)
+	assert.NoError(suite.T(), err)
+	//pay drain invoice
+	go suite.createPayInvoiceReqWithCancel(drainInvoice.PaymentRequest, suite.userToken)
+	time.Sleep(3 * time.Second)
+
+	//start payment checking loop
+	go func() {
+		err = suite.service.CheckAllPendingOutgoingPayments(context.Background())
+		assert.NoError(suite.T(), err)
+	}()
+	//wait a bit for routine to start
+	time.Sleep(time.Second)
+	//now settle both invoices with the maximum fee
+	suite.hodlLND.SettlePayment(lnrpc.Payment{
+		PaymentHash:     hex.EncodeToString(drainInvoice.RHash),
+		Value:           drainInv.Value,
+		CreationDate:    0,
+		FeeSat:          feeLimit,
+		PaymentPreimage: "preimage3",
+		ValueSat:        drainInv.Value,
+		ValueMsat:       0,
+		PaymentRequest:  invoice.PaymentRequest,
+		Status:          lnrpc.Payment_SUCCEEDED,
+		FailureReason:   0,
+	})
+	//wait a bit for db update to happen
+	time.Sleep(time.Second)
+	//send settle invoice with lnrpc.payment
+	suite.hodlLND.SettlePayment(lnrpc.Payment{
+		PaymentHash:     hex.EncodeToString(invoice.RHash),
+		Value:           externalInvoice.Value,
+		CreationDate:    0,
+		FeeSat:          feeLimit,
+		PaymentPreimage: "preimage2",
+		ValueSat:        externalInvoice.Value,
+		ValueMsat:       0,
+		PaymentRequest:  invoice.PaymentRequest,
+		Status:          lnrpc.Payment_SUCCEEDED,
+		FailureReason:   0,
+	})
+	//wait a bit for db update to happen
+	time.Sleep(time.Second)
+
+	if err != nil {
+		fmt.Printf("Error when getting balance %v\n", err.Error())
+	}
+	//fetch user balance again
+	userBalance, err := suite.service.CurrentUserBalance(context.Background(), userId)
+	assert.NoError(suite.T(), err)
+	//assert the balance is negative
+	assert.True(suite.T(), userBalance < 0)
+}
 
 func (suite *HodlInvoiceSuite) TearDownSuite() {
 	suite.invoiceUpdateSubCancelFn()

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -153,16 +153,16 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	errorString := "FAILURE_REASON_INCORRECT_PAYMENT_DETAILS"
 	assert.Equal(suite.T(), errorString, invoices[0].ErrorMessage)
 
-	transactonEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
+	transactionEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
 	if err != nil {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
 	// check if there are 3 transaction entries, with reversed credit and debit account ids
-	assert.Equal(suite.T(), 3, len(transactonEntries))
-	assert.Equal(suite.T(), transactonEntries[1].CreditAccountID, transactonEntries[2].DebitAccountID)
-	assert.Equal(suite.T(), transactonEntries[1].DebitAccountID, transactonEntries[2].CreditAccountID)
-	assert.Equal(suite.T(), transactonEntries[1].Amount, int64(externalSatRequested))
-	assert.Equal(suite.T(), transactonEntries[2].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), 3, len(transactionEntries))
+	assert.Equal(suite.T(), transactionEntries[1].CreditAccountID, transactionEntries[2].DebitAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].DebitAccountID, transactionEntries[2].CreditAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), transactionEntries[2].Amount, int64(externalSatRequested))
 
 	// create external invoice
 	externalInvoice = lnrpc.Invoice{

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -224,9 +224,6 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	inv, err = suite.service.FindInvoiceByPaymentHash(context.Background(), userId, hex.EncodeToString(invoice.RHash))
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.InvoiceStateSettled, inv.State)
-	clearTable(suite.service, "invoices")
-	clearTable(suite.service, "transaction_entries")
-	clearTable(suite.service, "accounts")
 }
 func (suite *HodlInvoiceSuite) TestNegativeBalanceWithHodl() {
 	//10M funding, 5M sat requested
@@ -315,6 +312,9 @@ func (suite *HodlInvoiceSuite) TestNegativeBalanceWithHodl() {
 }
 
 func (suite *HodlInvoiceSuite) TearDownSuite() {
+	clearTable(suite.service, "invoices")
+	clearTable(suite.service, "transaction_entries")
+	clearTable(suite.service, "accounts")
 	suite.invoiceUpdateSubCancelFn()
 }
 

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -240,7 +240,7 @@ func (suite *PaymentTestSuite) TestInternalPaymentFail() {
 	assert.Equal(suite.T(), 2, len(invoices))
 	assert.Equal(suite.T(), common.InvoiceStateError, invoices[0].State)
 	assert.Equal(suite.T(), common.InvoiceStateSettled, invoices[1].State)
-	transactonEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
+	transactionEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
 	if err != nil {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
@@ -250,15 +250,14 @@ func (suite *PaymentTestSuite) TestInternalPaymentFail() {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
 
-	// check if there are 5 transaction entries, with reversed credit and debit account ids for last 2
-	assert.Equal(suite.T(), 5, len(transactonEntries))
-	assert.Equal(suite.T(), int64(aliceFundingSats), transactonEntries[0].Amount)
-	assert.Equal(suite.T(), int64(bobSatRequested), transactonEntries[1].Amount)
-	assert.Equal(suite.T(), int64(fee), transactonEntries[2].Amount)
-	assert.Equal(suite.T(), transactonEntries[3].CreditAccountID, transactonEntries[4].DebitAccountID)
-	assert.Equal(suite.T(), transactonEntries[3].DebitAccountID, transactonEntries[4].CreditAccountID)
-	assert.Equal(suite.T(), transactonEntries[3].Amount, int64(bobSatRequested))
-	assert.Equal(suite.T(), transactonEntries[4].Amount, int64(bobSatRequested))
+	// check if there are 4 transaction entries, with reversed credit and debit account ids for last 2
+	assert.Equal(suite.T(), 4, len(transactionEntries))
+	assert.Equal(suite.T(), int64(aliceFundingSats), transactionEntries[0].Amount)
+	assert.Equal(suite.T(), int64(bobSatRequested), transactionEntries[1].Amount)
+	assert.Equal(suite.T(), transactionEntries[2].CreditAccountID, transactionEntries[3].DebitAccountID)
+	assert.Equal(suite.T(), transactionEntries[2].DebitAccountID, transactionEntries[3].CreditAccountID)
+	assert.Equal(suite.T(), transactionEntries[2].Amount, int64(bobSatRequested))
+	assert.Equal(suite.T(), transactionEntries[3].Amount, int64(bobSatRequested))
 	// assert that balance was reduced only once
 	assert.Equal(suite.T(), int64(aliceFundingSats)-int64(bobSatRequested+fee), int64(aliceBalance))
 }

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -171,13 +171,12 @@ func (suite *PaymentTestSuite) TestInternalPayment() {
 	suite.echo.ServeHTTP(rec, req)
 	assert.Equal(suite.T(), http.StatusBadRequest, rec.Code)
 
-	transactonEntriesAlice, _ := suite.service.TransactionEntriesFor(context.Background(), aliceId)
+	transactionEntriesAlice, _ := suite.service.TransactionEntriesFor(context.Background(), aliceId)
 	aliceBalance, _ := suite.service.CurrentUserBalance(context.Background(), aliceId)
-	assert.Equal(suite.T(), 3, len(transactonEntriesAlice))
-	assert.Equal(suite.T(), int64(aliceFundingSats), transactonEntriesAlice[0].Amount)
-	assert.Equal(suite.T(), int64(bobSatRequested), transactonEntriesAlice[1].Amount)
-	assert.Equal(suite.T(), int64(fee), transactonEntriesAlice[2].Amount)
-	assert.Equal(suite.T(), transactonEntriesAlice[1].ID, transactonEntriesAlice[2].ParentID)
+	assert.Equal(suite.T(), 2, len(transactionEntriesAlice))
+	assert.Equal(suite.T(), int64(aliceFundingSats), transactionEntriesAlice[0].Amount)
+	assert.Equal(suite.T(), int64(bobSatRequested), transactionEntriesAlice[1].Amount)
+	assert.Equal(suite.T(), transactionEntriesAlice[1].ID, transactionEntriesAlice[2].ParentID)
 	assert.Equal(suite.T(), int64(aliceFundingSats-bobSatRequested-fee), aliceBalance)
 
 	bobBalance, _ := suite.service.CurrentUserBalance(context.Background(), bobId)

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -176,7 +176,6 @@ func (suite *PaymentTestSuite) TestInternalPayment() {
 	assert.Equal(suite.T(), 2, len(transactionEntriesAlice))
 	assert.Equal(suite.T(), int64(aliceFundingSats), transactionEntriesAlice[0].Amount)
 	assert.Equal(suite.T(), int64(bobSatRequested), transactionEntriesAlice[1].Amount)
-	assert.Equal(suite.T(), transactionEntriesAlice[1].ID, transactionEntriesAlice[2].ParentID)
 	assert.Equal(suite.T(), int64(aliceFundingSats-bobSatRequested-fee), aliceBalance)
 
 	bobBalance, _ := suite.service.CurrentUserBalance(context.Background(), bobId)

--- a/integration_tests/lnd_mock_hodl.go
+++ b/integration_tests/lnd_mock_hodl.go
@@ -33,7 +33,7 @@ func (hps *HodlPaymentSubscriber) Recv() (*lnrpc.Payment, error) {
 func NewLNDMockHodlWrapperAsync(lnd lnd.LightningClientWrapper) (result *LNDMockHodlWrapperAsync, err error) {
 	return &LNDMockHodlWrapperAsync{
 		hps: &HodlPaymentSubscriber{
-			ch: make(chan lnrpc.Payment),
+			ch: make(chan lnrpc.Payment, 5),
 		},
 		LightningClientWrapper: lnd,
 	}, nil

--- a/integration_tests/outgoing_payment_test.go
+++ b/integration_tests/outgoing_payment_test.go
@@ -63,7 +63,7 @@ func (suite *PaymentTestSuite) TestOutGoingPayment() {
 	assert.Equal(suite.T(), 1, len(outgoingInvoices))
 	assert.Equal(suite.T(), 1, len(incomingInvoices))
 
-	assert.Equal(suite.T(), 3, len(transactonEntries))
+	assert.Equal(suite.T(), 5, len(transactonEntries))
 
 	assert.Equal(suite.T(), int64(aliceFundingSats), transactonEntries[0].Amount)
 	assert.Equal(suite.T(), currentAccount.ID, transactonEntries[0].CreditAccountID)
@@ -77,13 +77,13 @@ func (suite *PaymentTestSuite) TestOutGoingPayment() {
 	assert.Equal(suite.T(), int64(0), transactonEntries[1].ParentID)
 	assert.Equal(suite.T(), outgoingInvoices[0].ID, transactonEntries[1].InvoiceID)
 
-	assert.Equal(suite.T(), int64(suite.mlnd.fee), transactonEntries[2].Amount)
+	assert.Equal(suite.T(), int64(suite.mlnd.fee), transactonEntries[4].Amount)
 	assert.Equal(suite.T(), feeAccount.ID, transactonEntries[2].CreditAccountID)
 	assert.Equal(suite.T(), currentAccount.ID, transactonEntries[2].DebitAccountID)
 	assert.Equal(suite.T(), outgoingInvoices[0].ID, transactonEntries[2].InvoiceID)
 
 	// make sure fee entry parent id is previous entry
-	assert.Equal(suite.T(), transactonEntries[1].ID, transactonEntries[2].ParentID)
+	assert.Equal(suite.T(), transactonEntries[1].ID, transactonEntries[4].ParentID)
 
 	//fetch transactions, make sure the fee is there
 	// check invoices again
@@ -134,7 +134,7 @@ func (suite *PaymentTestSuite) TestOutGoingPaymentWithNegativeBalance() {
 	assert.Equal(suite.T(), int64(-1), aliceBalance)
 
 	// check that no additional transaction entry was created
-	transactonEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
+	transactionEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
 	if err != nil {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
@@ -149,27 +149,27 @@ func (suite *PaymentTestSuite) TestOutGoingPaymentWithNegativeBalance() {
 	assert.Equal(suite.T(), 1, len(outgoingInvoices))
 	assert.Equal(suite.T(), 1, len(incomingInvoices))
 
-	assert.Equal(suite.T(), 3, len(transactonEntries))
+	assert.Equal(suite.T(), 5, len(transactionEntries))
 
-	assert.Equal(suite.T(), int64(aliceFundingSats), transactonEntries[0].Amount)
-	assert.Equal(suite.T(), currentAccount.ID, transactonEntries[0].CreditAccountID)
-	assert.Equal(suite.T(), incomingAccount.ID, transactonEntries[0].DebitAccountID)
-	assert.Equal(suite.T(), int64(0), transactonEntries[0].ParentID)
-	assert.Equal(suite.T(), incomingInvoices[0].ID, transactonEntries[0].InvoiceID)
+	assert.Equal(suite.T(), int64(aliceFundingSats), transactionEntries[0].Amount)
+	assert.Equal(suite.T(), currentAccount.ID, transactionEntries[0].CreditAccountID)
+	assert.Equal(suite.T(), incomingAccount.ID, transactionEntries[0].DebitAccountID)
+	assert.Equal(suite.T(), int64(0), transactionEntries[0].ParentID)
+	assert.Equal(suite.T(), incomingInvoices[0].ID, transactionEntries[0].InvoiceID)
 
-	assert.Equal(suite.T(), int64(externalSatRequested), transactonEntries[1].Amount)
-	assert.Equal(suite.T(), outgoingAccount.ID, transactonEntries[1].CreditAccountID)
-	assert.Equal(suite.T(), currentAccount.ID, transactonEntries[1].DebitAccountID)
-	assert.Equal(suite.T(), int64(0), transactonEntries[1].ParentID)
-	assert.Equal(suite.T(), outgoingInvoices[0].ID, transactonEntries[1].InvoiceID)
+	assert.Equal(suite.T(), int64(externalSatRequested), transactionEntries[1].Amount)
+	assert.Equal(suite.T(), outgoingAccount.ID, transactionEntries[1].CreditAccountID)
+	assert.Equal(suite.T(), currentAccount.ID, transactionEntries[1].DebitAccountID)
+	assert.Equal(suite.T(), int64(0), transactionEntries[1].ParentID)
+	assert.Equal(suite.T(), outgoingInvoices[0].ID, transactionEntries[1].InvoiceID)
 
-	assert.Equal(suite.T(), int64(suite.mlnd.fee), transactonEntries[2].Amount)
-	assert.Equal(suite.T(), feeAccount.ID, transactonEntries[2].CreditAccountID)
-	assert.Equal(suite.T(), currentAccount.ID, transactonEntries[2].DebitAccountID)
-	assert.Equal(suite.T(), outgoingInvoices[0].ID, transactonEntries[2].InvoiceID)
+	assert.Equal(suite.T(), int64(suite.mlnd.fee), transactionEntries[4].Amount)
+	assert.Equal(suite.T(), feeAccount.ID, transactionEntries[2].CreditAccountID)
+	assert.Equal(suite.T(), currentAccount.ID, transactionEntries[2].DebitAccountID)
+	assert.Equal(suite.T(), outgoingInvoices[0].ID, transactionEntries[2].InvoiceID)
 
 	// make sure fee entry parent id is previous entry
-	assert.Equal(suite.T(), transactonEntries[1].ID, transactonEntries[2].ParentID)
+	assert.Equal(suite.T(), transactionEntries[1].ID, transactionEntries[4].ParentID)
 }
 
 func (suite *PaymentTestSuite) TestZeroAmountInvoice() {

--- a/integration_tests/payment_failure_async_test.go
+++ b/integration_tests/payment_failure_async_test.go
@@ -133,10 +133,10 @@ func (suite *PaymentTestAsyncErrorsSuite) TestExternalAsyncFailingInvoice() {
 	}
 	// check if there are 5 transaction entries, with reversed credit and debit account ids
 	assert.Equal(suite.T(), 5, len(transactionEntries))
-	assert.Equal(suite.T(), transactionEntries[1].CreditAccountID, transactionEntries[3].DebitAccountID)
-	assert.Equal(suite.T(), transactionEntries[1].DebitAccountID, transactionEntries[3].CreditAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].CreditAccountID, transactionEntries[4].DebitAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].DebitAccountID, transactionEntries[4].CreditAccountID)
 	assert.Equal(suite.T(), transactionEntries[1].Amount, int64(externalSatRequested))
-	assert.Equal(suite.T(), transactionEntries[3].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), transactionEntries[4].Amount, int64(externalSatRequested))
 }
 
 func (suite *PaymentTestAsyncErrorsSuite) TearDownSuite() {

--- a/integration_tests/payment_failure_async_test.go
+++ b/integration_tests/payment_failure_async_test.go
@@ -133,10 +133,10 @@ func (suite *PaymentTestAsyncErrorsSuite) TestExternalAsyncFailingInvoice() {
 	}
 	// check if there are 5 transaction entries, with reversed credit and debit account ids
 	assert.Equal(suite.T(), 5, len(transactionEntries))
-	assert.Equal(suite.T(), transactionEntries[1].CreditAccountID, transactionEntries[2].DebitAccountID)
-	assert.Equal(suite.T(), transactionEntries[1].DebitAccountID, transactionEntries[2].CreditAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].CreditAccountID, transactionEntries[3].DebitAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].DebitAccountID, transactionEntries[3].CreditAccountID)
 	assert.Equal(suite.T(), transactionEntries[1].Amount, int64(externalSatRequested))
-	assert.Equal(suite.T(), transactionEntries[2].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), transactionEntries[3].Amount, int64(externalSatRequested))
 }
 
 func (suite *PaymentTestAsyncErrorsSuite) TearDownSuite() {

--- a/integration_tests/payment_failure_async_test.go
+++ b/integration_tests/payment_failure_async_test.go
@@ -105,7 +105,8 @@ func (suite *PaymentTestAsyncErrorsSuite) TestExternalAsyncFailingInvoice() {
 	if err != nil {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
-	assert.Equal(suite.T(), int64(userFundingSats-externalSatRequested), userBalance)
+	feeReserve := suite.service.CalcFeeLimit(suite.externalLND.GetMainPubkey(), int64(externalSatRequested))
+	assert.Equal(suite.T(), int64(userFundingSats-externalSatRequested)-feeReserve, userBalance)
 
 	// fail payment and wait a bit
 	suite.serviceClient.FailPayment(SendPaymentMockError)
@@ -126,16 +127,16 @@ func (suite *PaymentTestAsyncErrorsSuite) TestExternalAsyncFailingInvoice() {
 	assert.Equal(suite.T(), common.InvoiceStateError, invoices[0].State)
 	assert.Equal(suite.T(), SendPaymentMockError, invoices[0].ErrorMessage)
 
-	transactonEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
+	transactionEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
 	if err != nil {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
-	// check if there are 3 transaction entries, with reversed credit and debit account ids
-	assert.Equal(suite.T(), 3, len(transactonEntries))
-	assert.Equal(suite.T(), transactonEntries[1].CreditAccountID, transactonEntries[2].DebitAccountID)
-	assert.Equal(suite.T(), transactonEntries[1].DebitAccountID, transactonEntries[2].CreditAccountID)
-	assert.Equal(suite.T(), transactonEntries[1].Amount, int64(externalSatRequested))
-	assert.Equal(suite.T(), transactonEntries[2].Amount, int64(externalSatRequested))
+	// check if there are 5 transaction entries, with reversed credit and debit account ids
+	assert.Equal(suite.T(), 5, len(transactionEntries))
+	assert.Equal(suite.T(), transactionEntries[1].CreditAccountID, transactionEntries[2].DebitAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].DebitAccountID, transactionEntries[2].CreditAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), transactionEntries[2].Amount, int64(externalSatRequested))
 }
 
 func (suite *PaymentTestAsyncErrorsSuite) TearDownSuite() {

--- a/integration_tests/payment_failure_test.go
+++ b/integration_tests/payment_failure_test.go
@@ -160,7 +160,7 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 	assert.Equal(suite.T(), transactionEntries[2].CreditAccountID, transactionEntries[3].DebitAccountID)
 	assert.Equal(suite.T(), transactionEntries[2].DebitAccountID, transactionEntries[3].CreditAccountID)
 	assert.Equal(suite.T(), transactionEntries[1].Amount, int64(externalSatRequested))
-	assert.Equal(suite.T(), transactionEntries[2].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), transactionEntries[3].Amount, int64(externalSatRequested))
 	// assert that balance is the same
 	assert.Equal(suite.T(), int64(userFundingSats), userBalance)
 }

--- a/integration_tests/payment_failure_test.go
+++ b/integration_tests/payment_failure_test.go
@@ -138,7 +138,7 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 	assert.Equal(suite.T(), common.InvoiceStateError, invoices[0].State)
 	assert.Equal(suite.T(), SendPaymentMockError, invoices[0].ErrorMessage)
 
-	transactonEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
+	transactionEntries, err := suite.service.TransactionEntriesFor(context.Background(), userId)
 	if err != nil {
 		fmt.Printf("Error when getting transaction entries %v\n", err.Error())
 	}
@@ -154,13 +154,13 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 	//  - the fee reserve + the fee reserve reversal
 	//  - the outgoing payment reversal
 	//  with reversed credit and debit account ids for payment 2/5 & payment 3/4
-	assert.Equal(suite.T(), 5, len(transactonEntries))
-	assert.Equal(suite.T(), transactonEntries[1].CreditAccountID, transactonEntries[4].DebitAccountID)
-	assert.Equal(suite.T(), transactonEntries[1].DebitAccountID, transactonEntries[4].CreditAccountID)
-	assert.Equal(suite.T(), transactonEntries[2].CreditAccountID, transactonEntries[3].DebitAccountID)
-	assert.Equal(suite.T(), transactonEntries[2].DebitAccountID, transactonEntries[3].CreditAccountID)
-	assert.Equal(suite.T(), transactonEntries[1].Amount, int64(externalSatRequested))
-	assert.Equal(suite.T(), transactonEntries[2].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), 5, len(transactionEntries))
+	assert.Equal(suite.T(), transactionEntries[1].CreditAccountID, transactionEntries[4].DebitAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].DebitAccountID, transactionEntries[4].CreditAccountID)
+	assert.Equal(suite.T(), transactionEntries[2].CreditAccountID, transactionEntries[3].DebitAccountID)
+	assert.Equal(suite.T(), transactionEntries[2].DebitAccountID, transactionEntries[3].CreditAccountID)
+	assert.Equal(suite.T(), transactionEntries[1].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), transactionEntries[2].Amount, int64(externalSatRequested))
 	// assert that balance is the same
 	assert.Equal(suite.T(), int64(userFundingSats), userBalance)
 }

--- a/integration_tests/payment_failure_test.go
+++ b/integration_tests/payment_failure_test.go
@@ -90,8 +90,8 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 
 	//test an expired invoice
 	externalInvoice := lnrpc.Invoice{
-		Memo:  "integration tests: external pay from alice",
-		Value: int64(externalSatRequested),
+		Memo:   "integration tests: external pay from alice",
+		Value:  int64(externalSatRequested),
 		Expiry: 1,
 	}
 	invoice, err := suite.externalLND.AddInvoice(context.Background(), &externalInvoice)
@@ -148,10 +148,17 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 		fmt.Printf("Error when getting balance %v\n", err.Error())
 	}
 
-	// check if there are 3 transaction entries, with reversed credit and debit account ids
-	assert.Equal(suite.T(), 3, len(transactonEntries))
-	assert.Equal(suite.T(), transactonEntries[1].CreditAccountID, transactonEntries[2].DebitAccountID)
-	assert.Equal(suite.T(), transactonEntries[1].DebitAccountID, transactonEntries[2].CreditAccountID)
+	// check if there are 5 transaction entries:
+	//	- the incoming payment
+	//  - the outgoing payment
+	//  - the fee reserve + the fee reserve reversal
+	//  - the outgoing payment reversal
+	//  with reversed credit and debit account ids for payment 2/5 & payment 3/4
+	assert.Equal(suite.T(), 5, len(transactonEntries))
+	assert.Equal(suite.T(), transactonEntries[1].CreditAccountID, transactonEntries[4].DebitAccountID)
+	assert.Equal(suite.T(), transactonEntries[1].DebitAccountID, transactonEntries[4].CreditAccountID)
+	assert.Equal(suite.T(), transactonEntries[2].CreditAccountID, transactonEntries[3].DebitAccountID)
+	assert.Equal(suite.T(), transactonEntries[2].DebitAccountID, transactonEntries[3].CreditAccountID)
 	assert.Equal(suite.T(), transactonEntries[1].Amount, int64(externalSatRequested))
 	assert.Equal(suite.T(), transactonEntries[2].Amount, int64(externalSatRequested))
 	// assert that balance is the same

--- a/integration_tests/payment_failure_test.go
+++ b/integration_tests/payment_failure_test.go
@@ -160,7 +160,7 @@ func (suite *PaymentTestErrorsSuite) TestExternalFailingInvoice() {
 	assert.Equal(suite.T(), transactionEntries[2].CreditAccountID, transactionEntries[3].DebitAccountID)
 	assert.Equal(suite.T(), transactionEntries[2].DebitAccountID, transactionEntries[3].CreditAccountID)
 	assert.Equal(suite.T(), transactionEntries[1].Amount, int64(externalSatRequested))
-	assert.Equal(suite.T(), transactionEntries[3].Amount, int64(externalSatRequested))
+	assert.Equal(suite.T(), transactionEntries[4].Amount, int64(externalSatRequested))
 	// assert that balance is the same
 	assert.Equal(suite.T(), int64(userFundingSats), userBalance)
 }

--- a/lib/service/checkpayments.go
+++ b/lib/service/checkpayments.go
@@ -13,15 +13,15 @@ import (
 )
 
 func (svc *LndhubService) GetAllPendingPayments(ctx context.Context) ([]models.Invoice, error) {
-    payments := []models.Invoice{}
-    err := svc.DB.NewSelect().Model(&payments).Where("state = 'initialized'").Where("type = 'outgoing'").Where("r_hash != ''").Where("created_at >= (now() - interval '2 weeks') ").Scan(ctx)
-    return payments, err
+	payments := []models.Invoice{}
+	err := svc.DB.NewSelect().Model(&payments).Where("state = 'initialized'").Where("type = 'outgoing'").Where("r_hash != ''").Where("created_at >= (now() - interval '2 weeks') ").Scan(ctx)
+	return payments, err
 }
 func (svc *LndhubService) CheckAllPendingOutgoingPayments(ctx context.Context) (err error) {
-    pendingPayments, err := svc.GetAllPendingPayments(ctx)
-    if err != nil {
-        return err
-    }
+	pendingPayments, err := svc.GetAllPendingPayments(ctx)
+	if err != nil {
+		return err
+	}
 
 	svc.Logger.Infof("Found %d pending payments", len(pendingPayments))
 	//call trackoutgoingpaymentstatus for each one
@@ -42,10 +42,19 @@ func (svc *LndhubService) CheckAllPendingOutgoingPayments(ctx context.Context) (
 }
 
 func (svc *LndhubService) GetTransactionEntryByInvoiceId(ctx context.Context, id int64) (models.TransactionEntry, error) {
-    entry := models.TransactionEntry{}
+	entry := models.TransactionEntry{}
+	feeReserveEntry := models.TransactionEntry{}
 
-    err := svc.DB.NewSelect().Model(&entry).Where("invoice_id = ?", id).Limit(1).Scan(ctx)
-    return entry, err
+	err := svc.DB.NewSelect().Model(&entry).Where("invoice_id = ? and entry_type = ?", id, models.EntryTypeOutgoing).Limit(1).Scan(ctx)
+	if err != nil {
+		return entry, err
+	}
+	err = svc.DB.NewSelect().Model(&feeReserveEntry).Where("invoice_id = ? and entry_type = ?", id, models.EntryTypeFeeReserve).Limit(1).Scan(ctx)
+	if err != nil {
+		return entry, err
+	}
+	entry.FeeReserve = &feeReserveEntry
+	return entry, err
 }
 
 // Should be called in a goroutine as the tracking can potentially take a long time
@@ -72,7 +81,7 @@ func (svc *LndhubService) TrackOutgoingPaymentstatus(ctx context.Context, invoic
 			svc.Logger.Errorf("Error tracking payment with hash %s: %s", invoice.RHash, err.Error())
 			return
 		}
-        entry, err := svc.GetTransactionEntryByInvoiceId(ctx, invoice.ID)
+		entry, err := svc.GetTransactionEntryByInvoiceId(ctx, invoice.ID)
 		if err != nil {
 			svc.Logger.Errorf("Error tracking payment %s: %s", invoice.RHash, err.Error())
 			return

--- a/lib/service/checkpayments.go
+++ b/lib/service/checkpayments.go
@@ -93,6 +93,7 @@ func (svc *LndhubService) TrackOutgoingPaymentstatus(ctx context.Context, invoic
 		}
 		if payment.Status == lnrpc.Payment_FAILED {
 			svc.Logger.Infof("Failed payment detected: hash %s, reason %s", payment.PaymentHash, payment.FailureReason)
+			fmt.Println(entry.FeeReserve)
 			err = svc.HandleFailedPayment(ctx, invoice, entry, fmt.Errorf(payment.FailureReason.String()))
 			if err != nil {
 				sentry.CaptureException(err)

--- a/lib/service/checkpayments.go
+++ b/lib/service/checkpayments.go
@@ -93,7 +93,6 @@ func (svc *LndhubService) TrackOutgoingPaymentstatus(ctx context.Context, invoic
 		}
 		if payment.Status == lnrpc.Payment_FAILED {
 			svc.Logger.Infof("Failed payment detected: hash %s, reason %s", payment.PaymentHash, payment.FailureReason)
-			fmt.Println(entry.FeeReserve)
 			err = svc.HandleFailedPayment(ctx, invoice, entry, fmt.Errorf(payment.FailureReason.String()))
 			if err != nil {
 				sentry.CaptureException(err)

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -82,6 +82,7 @@ func (svc *LndhubService) SendInternalPayment(ctx context.Context, invoice *mode
 		CreditAccountID: recipientCreditAccount.ID,
 		DebitAccountID:  recipientDebitAccount.ID,
 		Amount:          invoice.Amount,
+		EntryType:       models.EntryTypeIncoming,
 	}
 	_, err = svc.DB.NewInsert().Model(&recipientEntry).Exec(ctx)
 	if err != nil {
@@ -203,6 +204,7 @@ func (svc *LndhubService) PayInvoice(ctx context.Context, invoice *models.Invoic
 		CreditAccountID: creditAccount.ID,
 		DebitAccountID:  debitAccount.ID,
 		Amount:          invoice.Amount,
+		EntryType:       models.EntryTypeOutgoing,
 	}
 
 	// The DB constraints make sure the user actually has enough balance for the transaction
@@ -258,6 +260,7 @@ func (svc *LndhubService) HandleFailedPayment(ctx context.Context, invoice *mode
 		CreditAccountID: entryToRevert.DebitAccountID,
 		DebitAccountID:  entryToRevert.CreditAccountID,
 		Amount:          invoice.Amount,
+		EntryType:       models.EntryTypeOutgoingReversal,
 	}
 	_, err = tx.NewInsert().Model(&entry).Exec(ctx)
 	if err != nil {
@@ -313,6 +316,7 @@ func (svc *LndhubService) HandleSuccessfulPayment(ctx context.Context, invoice *
 		DebitAccountID:  parentEntry.DebitAccountID,
 		Amount:          int64(invoice.Fee),
 		ParentID:        parentEntry.ID,
+		EntryType:       models.EntryTypeFee,
 	}
 	_, err = svc.DB.NewInsert().Model(&entry).Exec(ctx)
 	if err != nil {

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -402,7 +402,7 @@ func (svc *LndhubService) HandleSuccessfulPayment(ctx context.Context, invoice *
 		return err
 	}
 
-	//revert the fee reserve entry
+	//add the real fee entry
 	err = svc.AddFeeEntry(ctx, &parentEntry, invoice, tx)
 	if err != nil {
 		tx.Rollback()

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -330,6 +330,10 @@ func (svc *LndhubService) InsertTransactionEntry(ctx context.Context, invoice *m
 		}
 		entry.FeeReserve = &feeReserveEntry
 	}
+	err = tx.Commit()
+	if err != nil {
+		return entry, err
+	}
 	return entry, err
 }
 

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -264,7 +264,7 @@ func (svc *LndhubService) HandleFailedPayment(ctx context.Context, invoice *mode
 		return err
 	}
 
-	err = svc.RevertFeeReserve(ctx, &entry, tx)
+	err = svc.RevertFeeReserve(ctx, &entryToRevert, tx)
 	if err != nil {
 		sentry.CaptureException(err)
 		svc.Logger.Errorf("Could not revert fee reserve entry entry user_id:%v invoice_id:%v error %s", invoice.UserID, invoice.ID, err.Error())

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -323,7 +323,7 @@ func (svc *LndhubService) InsertTransactionEntry(ctx context.Context, invoice *m
 			InvoiceID:       invoice.ID,
 			CreditAccountID: feeAccount.ID,
 			DebitAccountID:  debitAccount.ID,
-			Amount:          invoice.Amount,
+			Amount:          feeLimit,
 			EntryType:       models.EntryTypeFeeReserve,
 		}
 		_, err = tx.NewInsert().Model(&feeReserveEntry).Exec(ctx)

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -346,7 +346,7 @@ func (svc *LndhubService) RevertFeeReserve(ctx context.Context, entry *models.Tr
 			CreditAccountID: entryToRevert.DebitAccountID,
 			DebitAccountID:  entryToRevert.CreditAccountID,
 			Amount:          entryToRevert.Amount,
-			EntryType:       models.EntryTypeOutgoingReversal,
+			EntryType:       models.EntryTypeFeeReserveReversal,
 		}
 		_, err = tx.NewInsert().Model(&feeReserveRevert).Exec(ctx)
 		return err

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -163,6 +163,7 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 			CreditAccountID: creditAccount.ID,
 			DebitAccountID:  debitAccount.ID,
 			Amount:          rawInvoice.AmtPaidSat,
+			EntryType:       models.EntryTypeIncoming,
 		}
 		// Save the transaction entry
 		_, err = tx.NewInsert().Model(&entry).Exec(ctx)


### PR DESCRIPTION
This PR ensures that there is no way an account can go below 0. 

- A new `entry_type` field is added to the transaction entry model to indicate the different types: `incoming`, `outgoing`, `outgoing_reversal`, `fee_reserve`, `fee_reserve_reversal`, `fee`.
- When making an non-internal transaction the fee reserve is debited from the current account.
- When the payment has completed, the `fee_reserve` entry is always reversed if there is one. This is done regardless if lndhub has restarted in the meantime or not.
- The database constraint on unique tx entry tuples is updated to include the new `entry_type` field (because we now have identical entries under the previous schema).
- An integration test has been added that would previously make an account go below 0.
- Existing integration tests also needed to be updated because they assumed a standard payment has 2 transaction entries associated with it (outgoing + fee or outgoing + reversal), whereas it now has 4 transaction entries associated with it ( fee_reserve + fee_reserve reversal are always there in addition to the ones mentioned above).

To do:
- [x] fix integration tests
- [x] add new integration test to ensure this works as intended.