### PR TITLE
Chore: RabbitMQ logging

### DIFF
--- a/init_lnd.go
+++ b/init_lnd.go
@@ -30,6 +30,9 @@ func InitSingleLNDClient(c *service.Config, ctx context.Context) (result lnd.Lig
 		CertFile:     c.LNDCertFile,
 		CertHex:      c.LNDCertHex,
 	}, ctx)
+	if err != nil {
+		return nil, err
+	}
 	getInfo, err := client.GetInfo(ctx, &lnrpc.GetInfoRequest{})
 	if err != nil {
 		return nil, err

--- a/rabbitmq/rabbitmq.go
+++ b/rabbitmq/rabbitmq.go
@@ -205,6 +205,11 @@ func (client *DefaultClient) FinalizeInitializedPayments(ctx context.Context, sv
 
 					continue
 				}
+				client.logger.Infoj(log.JSON{
+					"subroutine":   "payment finalizer",
+					"payment_hash": invoice.RHash,
+					"message":      "updating payment",
+				})
 
 				switch payment.Status {
 				case lnrpc.Payment_SUCCEEDED:
@@ -222,7 +227,11 @@ func (client *DefaultClient) FinalizeInitializedPayments(ctx context.Context, sv
 						continue
 					}
 
-					client.logger.Infof("Payment finalizer: updated successful payment with hash: %s", payment.PaymentHash)
+					client.logger.Infoj(log.JSON{
+						"subroutine":   "payment finalizer",
+						"message":      "updated succesful payment",
+						"payment_hash": payment.PaymentHash,
+					})
 					delete(pendingInvoices, payment.PaymentHash)
 
 				case lnrpc.Payment_FAILED:
@@ -236,8 +245,11 @@ func (client *DefaultClient) FinalizeInitializedPayments(ctx context.Context, sv
 
 						continue
 					}
-
-					client.logger.Infof("Payment finalizer: updated failed payment with hash: %s", payment.PaymentHash)
+					client.logger.Infoj(log.JSON{
+						"subroutine":   "payment finalizer",
+						"message":      "updated failed payment",
+						"payment_hash": payment.PaymentHash,
+					})
 					delete(pendingInvoices, payment.PaymentHash)
 				}
 			}
@@ -288,6 +300,11 @@ func (client *DefaultClient) SubscribeToLndInvoices(ctx context.Context, handler
 
 				continue
 			}
+			log.Infoj(log.JSON{
+				"subroutine":   "invoice consumer",
+				"message":      "adding invoice",
+				"payment_hash": invoice.RHash,
+			})
 
 			err = handler(ctx, &invoice)
 			if err != nil {


### PR DESCRIPTION
Fixes #411 
This PR adds metadata fields to the logs from the processes that use Rabbitmq: payment consumer, invoice consumer and publisher routines. This will help us identify issues and also allow us to trace payments/invoices across services.

I also propose a standardized way of naming metadata fields (I would propose snake case), so we can search for them in datadag across different service logs:
 - `payment_hash` (only one used in this PR)
 - `lndhub_user_id`, `getalbycom_user_id`
 - `invoice_id`
 - `message`
 - `error` 
 - etc

We would need some follow up PR's in order to implement this kind of structured logging across LNDhub & other services.