### PR TITLE
Feature/add max volume

### DIFF
--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -95,7 +95,7 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 	}
 	if resp != nil {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
-		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
+		return c.JSON(http.StatusBadRequest, resp)
 	}
 	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, "", lnPayReq)
 	if err != nil {

--- a/controllers/keysend.ctrl.go
+++ b/controllers/keysend.ctrl.go
@@ -82,7 +82,7 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 		})
 	}
 
-	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
+	resp, err := controller.svc.CheckPaymentAllowed(c.Request().Context(), lnPayReq, userID)
 	if err != nil {
 		c.Logger().Errorj(
 			log.JSON{
@@ -93,7 +93,7 @@ func (controller *KeySendController) KeySend(c echo.Context) error {
 		)
 		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
-	if !ok {
+	if resp != nil {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
 		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
 	}

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -110,7 +110,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	}
 	if resp != nil {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
-		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
+		return c.JSON(http.StatusBadRequest, resp)
 	}
 
 	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, paymentRequest, lnPayReq)

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -97,7 +97,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		}
 	}
 
-	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
+	resp, err := controller.svc.CheckPaymentAllowed(c.Request().Context(), lnPayReq, userID)
 	if err != nil {
 		c.Logger().Errorj(
 			log.JSON{
@@ -108,7 +108,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		)
 		return c.JSON(http.StatusBadRequest, responses.GeneralServerError)
 	}
-	if !ok {
+	if resp != nil {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
 		return c.JSON(http.StatusBadRequest, responses.NotEnoughBalanceError)
 	}

--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -171,12 +171,12 @@ func (controller *KeySendController) SingleKeySend(c echo.Context, reqBody *KeyS
 			HttpStatusCode: 400,
 		}
 	}
-	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
+	resp, err := controller.svc.CheckPaymentAllowed(c.Request().Context(), lnPayReq, userID)
 	if err != nil {
 		controller.svc.Logger.Error(err)
 		return nil, &responses.GeneralServerError
 	}
-	if !ok {
+	if resp != nil {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
 		return nil, &responses.NotEnoughBalanceError
 	}

--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -178,7 +178,7 @@ func (controller *KeySendController) SingleKeySend(c echo.Context, reqBody *KeyS
 	}
 	if resp != nil {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
-		return nil, &responses.NotEnoughBalanceError
+		return nil, resp
 	}
 	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, "", lnPayReq)
 	if err != nil {

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -111,7 +111,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	}
 	if resp != nil {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
-		return c.JSON(http.StatusInternalServerError, responses.NotEnoughBalanceError)
+		return c.JSON(http.StatusInternalServerError, resp)
 	}
 	invoice, err := controller.svc.AddOutgoingInvoice(c.Request().Context(), userID, paymentRequest, lnPayReq)
 	if err != nil {

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -98,7 +98,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		}
 		lnPayReq.PayReq.NumSatoshis = amt
 	}
-	ok, err := controller.svc.BalanceCheck(c.Request().Context(), lnPayReq, userID)
+	resp, err := controller.svc.CheckPaymentAllowed(c.Request().Context(), lnPayReq, userID)
 	if err != nil {
 		c.Logger().Errorj(
 			log.JSON{
@@ -109,7 +109,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		)
 		return err
 	}
-	if !ok {
+	if resp != nil {
 		c.Logger().Errorf("User does not have enough balance user_id:%v amount:%v", userID, lnPayReq.PayReq.NumSatoshis)
 		return c.JSON(http.StatusInternalServerError, responses.NotEnoughBalanceError)
 	}

--- a/db/migrations/20230928130000_add_invoice_settled_index.up.sql
+++ b/db/migrations/20230928130000_add_invoice_settled_index.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS index_invoices_on_user_id_settled_at
+  ON invoices(user_id, settled_at)
+  INCLUDE(amount);

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -133,6 +133,67 @@ func (suite *PaymentTestSuite) TestPaymentFeeReserve() {
 	//reset fee reserve so it's not used in other tests
 	suite.service.Config.FeeReserve = false
 }
+func (suite *PaymentTestSuite) TestVolumeExceeded() {
+	//this will cause the payment to fail as the account was already funded
+	//with 1000 sats
+	suite.service.Config.MaxVolume = 999
+	suite.service.Config.MaxVolumePeriod = 2592000
+	aliceFundingSats := 1000
+	//fund alice account
+	invoiceResponse := suite.createAddInvoiceReq(aliceFundingSats, "integration test internal payment alice", suite.aliceToken)
+	err := suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
+	assert.NoError(suite.T(), err)
+
+	//wait a bit for the payment to be processed
+	time.Sleep(10 * time.Millisecond)
+
+	//try to make external payment
+	//which should fail
+	//create external invoice
+	externalSatRequested := 1000
+	externalInvoice := lnrpc.Invoice{
+		Memo:  "integration tests: external pay from user",
+		Value: int64(externalSatRequested),
+	}
+	invoice, err := suite.externalLND.AddInvoice(context.Background(), &externalInvoice)
+	assert.NoError(suite.T(), err)
+	//pay external invoice
+	rec := httptest.NewRecorder()
+	var buf bytes.Buffer
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedPayInvoiceRequestBody{
+		Invoice: invoice.PaymentRequest,
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/payinvoice", &buf)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.aliceToken))
+	suite.echo.ServeHTTP(rec, req)
+	//should fail because max volume check
+	assert.Equal(suite.T(), http.StatusBadRequest, rec.Code)
+	resp := &responses.ErrorResponse{}
+	err = json.NewDecoder(rec.Body).Decode(resp)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), responses.TooMuchVolumeError.Message, resp.Message)
+
+	//change the period to be 1 second, sleep for 2 seconds, try to make another payment, this should work
+	suite.service.Config.MaxVolumePeriod = 1
+	time.Sleep(2 * time.Second)
+	rec = httptest.NewRecorder()
+	externalInvoice = lnrpc.Invoice{
+		Memo:  "integration tests: external pay from user",
+		Value: int64(externalSatRequested),
+	}
+	invoice, err = suite.externalLND.AddInvoice(context.Background(), &externalInvoice)
+	assert.NoError(suite.T(), err)
+	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedPayInvoiceRequestBody{
+		Invoice: invoice.PaymentRequest,
+	}))
+	suite.echo.ServeHTTP(rec, req)
+	assert.Equal(suite.T(), http.StatusOK, rec.Code)
+
+	//change the config back
+	suite.service.Config.MaxVolumePeriod = 0
+	suite.service.Config.MaxVolume = 1e6
+}
 func (suite *PaymentTestSuite) TestInternalPayment() {
 	aliceFundingSats := 1000
 	bobSatRequested := 500

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -51,7 +51,6 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 		DatabaseMaxConns:        1,
 		DatabaseMaxIdleConns:    1,
 		DatabaseConnMaxLifetime: 10,
-		MaxFeeAmount:            1e6,
 		JWTSecret:               []byte("SECRET"),
 		JWTAccessTokenExpiry:    3600,
 		JWTRefreshTokenExpiry:   3600,

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -51,7 +51,7 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 		DatabaseMaxConns:        1,
 		DatabaseMaxIdleConns:    1,
 		DatabaseConnMaxLifetime: 10,
-		MaxFeeAmount:            1e6, //todo: add max fee test
+		MaxFeeAmount:            1e6,
 		JWTSecret:               []byte("SECRET"),
 		JWTAccessTokenExpiry:    3600,
 		JWTRefreshTokenExpiry:   3600,

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -51,7 +51,7 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 		DatabaseMaxConns:        1,
 		DatabaseMaxIdleConns:    1,
 		DatabaseConnMaxLifetime: 10,
-		MaxFeeAmount:            1000000, //todo: add max fee test
+		MaxFeeAmount:            1e6, //todo: add max fee test
 		JWTSecret:               []byte("SECRET"),
 		JWTAccessTokenExpiry:    3600,
 		JWTRefreshTokenExpiry:   3600,

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -51,6 +51,7 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 		DatabaseMaxConns:        1,
 		DatabaseMaxIdleConns:    1,
 		DatabaseConnMaxLifetime: 10,
+		MaxFeeAmount:            1000000, //todo: add max fee test
 		JWTSecret:               []byte("SECRET"),
 		JWTAccessTokenExpiry:    3600,
 		JWTRefreshTokenExpiry:   3600,

--- a/lib/responses/errors.go
+++ b/lib/responses/errors.go
@@ -64,6 +64,13 @@ var NotEnoughBalanceError = ErrorResponse{
 	HttpStatusCode: 400,
 }
 
+var TooMuchVolumeError = ErrorResponse{
+	Error:          true,
+	Code:           2,
+	Message:        "transaction volume too high. please contact support for further assistance.",
+	HttpStatusCode: 400,
+}
+
 var AccountDeactivatedError = ErrorResponse{
 	Error:          true,
 	Code:           1,

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	MaxSendAmount                    int64   `envconfig:"MAX_SEND_AMOUNT" default:"0"`
 	MaxAccountBalance                int64   `envconfig:"MAX_ACCOUNT_BALANCE" default:"0"`
 	MaxFeeAmount                     int64   `envconfig:"MAX_FEE_AMOUNT" default:"5000"`
-	MaxVolume                        int64   `envconfig:"MAX_VOLUME" default:"5000000"`
+	MaxVolume                        int64   `envconfig:"MAX_VOLUME" default:"0"`              //0 means the volume check is disabled by default
 	MaxVolumePeriod                  int64   `envconfig:"MAX_VOLUME_PERIOD" default:"2592000"` //in seconds, default 1 month
 	RabbitMQUri                      string  `envconfig:"RABBITMQ_URI"`
 	RabbitMQLndhubInvoiceExchange    string  `envconfig:"RABBITMQ_INVOICE_EXCHANGE" default:"lndhub_invoice"`

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	MaxSendAmount                    int64   `envconfig:"MAX_SEND_AMOUNT" default:"0"`
 	MaxAccountBalance                int64   `envconfig:"MAX_ACCOUNT_BALANCE" default:"0"`
 	MaxFeeAmount                     int64   `envconfig:"MAX_FEE_AMOUNT" default:"5000"`
+	MaxVolume                        int64   `envconfig:"MAX_VOLUME" default:"5000000"`
+	MaxVolumePeriod                  int64   `envconfig:"MAX_VOLUME_PERIOD" default:"2592000"` //in seconds, default 1 month
 	RabbitMQUri                      string  `envconfig:"RABBITMQ_URI"`
 	RabbitMQLndhubInvoiceExchange    string  `envconfig:"RABBITMQ_INVOICE_EXCHANGE" default:"lndhub_invoice"`
 	RabbitMQLndInvoiceExchange       string  `envconfig:"RABBITMQ_LND_INVOICE_EXCHANGE" default:"lnd_invoice"`

--- a/lib/service/invoices_test.go
+++ b/lib/service/invoices_test.go
@@ -10,6 +10,9 @@ import (
 
 var svc = &LndhubService{
 	LndClient: &lnd.LNDWrapper{IdentityPubkey: "123pubkey"},
+	Config: &Config{
+		MaxFeeAmount: 1e6,
+	},
 }
 
 func TestCalcFeeWithInvoiceLessThan1000(t *testing.T) {

--- a/lib/service/invoices_test.go
+++ b/lib/service/invoices_test.go
@@ -45,3 +45,14 @@ func TestCalcFeeWithInvoiceMoreThan1000(t *testing.T) {
 	expectedFee := int64(16)
 	assert.Equal(t, expectedFee, feeLimit)
 }
+
+func TestCalcFeeWithMaxGlobalFee(t *testing.T) {
+	invoice := &models.Invoice{
+		Amount: 1500,
+	}
+	svc.Config.MaxFeeAmount = 1
+
+	feeLimit := svc.CalcFeeLimit("dummy", invoice.Amount)
+	expectedFee := svc.Config.MaxFeeAmount
+	assert.Equal(t, expectedFee, feeLimit)
+}

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -208,7 +208,6 @@ func (svc *LndhubService) GetVolumeOverPeriod(ctx context.Context, userId int64,
 	err = svc.DB.NewSelect().Table("invoices").
 		ColumnExpr("sum(invoices.amount) as result").
 		Where("invoices.user_id = ?", userId).
-		Where("invoices.state = ?", common.InvoiceStateSettled).
 		Where("invoices.settled_at >= ?", time.Now().Add(-1*period)).
 		Scan(ctx, &result)
 	if err != nil {

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -133,7 +133,7 @@ func (svc *LndhubService) CheckPaymentAllowed(ctx context.Context, lnpayReq *lnd
 	if svc.Config.FeeReserve {
 		minimumBalance += svc.CalcFeeLimit(lnpayReq.PayReq.Destination, lnpayReq.PayReq.NumSatoshis)
 	}
-	if currentBalance >= minimumBalance {
+	if currentBalance < minimumBalance {
 		return &responses.NotEnoughBalanceError, nil
 	}
 	volume, err := svc.GetVolumeOverPeriod(ctx, userId, time.Duration(svc.Config.MaxVolumePeriod*int64(time.Second)))

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/security"
 	"github.com/getAlby/lndhub.go/lnd"
+	"github.com/getsentry/sentry-go"
 	"github.com/uptrace/bun"
 	passwordvalidator "github.com/wagslane/go-password-validator"
 )
@@ -141,6 +142,7 @@ func (svc *LndhubService) CheckPaymentAllowed(ctx context.Context, lnpayReq *lnd
 		return nil, err
 	}
 	if volume > svc.Config.MaxVolume {
+		sentry.CaptureMessage(fmt.Sprintf("transaction volume exceeded for user %d", userId))
 		return &responses.TooMuchVolumeError, nil
 	}
 	return nil, nil

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -137,13 +137,16 @@ func (svc *LndhubService) CheckPaymentAllowed(ctx context.Context, lnpayReq *lnd
 	if currentBalance < minimumBalance {
 		return &responses.NotEnoughBalanceError, nil
 	}
-	volume, err := svc.GetVolumeOverPeriod(ctx, userId, time.Duration(svc.Config.MaxVolumePeriod*int64(time.Second)))
-	if err != nil {
-		return nil, err
-	}
-	if volume > svc.Config.MaxVolume {
-		sentry.CaptureMessage(fmt.Sprintf("transaction volume exceeded for user %d", userId))
-		return &responses.TooMuchVolumeError, nil
+	//only check for volume if configured
+	if svc.Config.MaxVolume > 0 {
+		volume, err := svc.GetVolumeOverPeriod(ctx, userId, time.Duration(svc.Config.MaxVolumePeriod*int64(time.Second)))
+		if err != nil {
+			return nil, err
+		}
+		if volume > svc.Config.MaxVolume {
+			sentry.CaptureMessage(fmt.Sprintf("transaction volume exceeded for user %d", userId))
+			return &responses.TooMuchVolumeError, nil
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
This PR implements an extra check when doing payments. If the total transaction volume of the account (incoming + outgoing) over a certain period is bigger than the configured values, it will block the payment (and send a sentry notification). 

- Fix existing tests (were broken due to issues introduced with #392 )
- Refactor `BalanceCheck` to `CheckPaymentAllowed` which will now perform the balance check and the volume check
- Add extra error response type for volume exceeded
- integration test

Default configuration is no limit.


example response:

```
http POST localhost:3000/v2/payments/keysend < keysend.json Authorization:"Bearer $token";
HTTP/1.1 400 Bad Request
Content-Length: 112
Content-Type: application/json; charset=UTF-8
Date: Mon, 25 Sep 2023 08:52:50 GMT
X-Request-Id: M3bd0Hkrvg0e7qg0e5rZX9glAUeWUEKE

{
    "code": 2,
    "error": true,
    "message": "transaction volume too high. please contact support for further assistance."
}
``` 