### PR TITLE
remove getinfo call when initializing cluster

### DIFF
--- a/lnd/config.go
+++ b/lnd/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	LNDCertHex                   string  `envconfig:"LND_CERT_HEX"`
 	LNDClusterLivenessPeriod     int     `envconfig:"LND_CLUSTER_LIVENESS_PERIOD" default:"10"`
 	LNDClusterActiveChannelRatio float64 `envconfig:"LND_CLUSTER_ACTIVE_CHANNEL_RATIO" default:"0.5"`
+	LNDClusterPubkeys            string  `envconfig:"LND_CLUSTER_PUBKEYS"` //comma-seperated list of public keys of the cluster
 }
 
 func LoadConfig() (c *Config, err error) {


### PR DESCRIPTION
Tested and this seems like it can work.

This removes the need to crash when we can't connect to one of the LND nodes at startup, which can happen when the Lightning nodes & the LNDHub pods are all restarted at the same time.

We get the public keys of the nodes by putting them in the configuration. That way we can know which invoices are internal and which are external.