### PR TITLE
legacy endpoint: no errored invoices

### DIFF
--- a/controllers/gettxs.ctrl.go
+++ b/controllers/gettxs.ctrl.go
@@ -65,6 +65,10 @@ func (controller *GetTXSController) GetTXS(c echo.Context) error {
 
 	response := make([]OutgoingInvoice, len(invoices))
 	for i, invoice := range invoices {
+		//only return settled invoices
+		if invoice.State != common.InvoiceStateSettled {
+			continue
+		}
 		rhash, _ := lib.ToJavaScriptBuffer(invoice.RHash)
 		response[i] = OutgoingInvoice{
 			RHash:           rhash,


### PR DESCRIPTION
As discussed on [slack](https://getalby.slack.com/archives/C02TDCWNX0T/p1696837586971999)

This stops failed payments from showing up in Zeus.