### PR TITLE
Refactor reconciliation

### DIFF
--- a/cmd/payment-reconciliation/main.go
+++ b/cmd/payment-reconciliation/main.go
@@ -75,6 +75,9 @@ func main() {
 	//for this job, we only search for payments older than a day to avoid current in-flight payments
 	ts := time.Now().Add(-1 * 24 * time.Hour)
 	pending, err := svc.GetPendingPaymentsUntil(startupCtx, ts)
+	svc.Logger.Infof("Found %d pending payments", len(pending))
+	startupCtx, cancel := context.WithTimeout(startupCtx, 2*time.Minute)
+	defer cancel()
 	err = svc.CheckPendingOutgoingPayments(startupCtx, pending)
 	if err != nil {
 		sentry.CaptureException(err)

--- a/cmd/payment-reconciliation/main.go
+++ b/cmd/payment-reconciliation/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/getAlby/lndhub.go/db"
 	"github.com/getAlby/lndhub.go/lib"
@@ -71,7 +72,10 @@ func main() {
 		InvoicePubSub: service.NewPubsub(),
 	}
 
-	err = svc.CheckAllPendingOutgoingPayments(startupCtx)
+	//for this job, we only search for payments older than a day to avoid current in-flight payments
+	ts := time.Now().Add(-1 * 24 * time.Hour)
+	pending, err := svc.GetPendingPaymentsUntil(startupCtx, ts)
+	err = svc.CheckPendingOutgoingPayments(startupCtx, pending)
 	if err != nil {
 		sentry.CaptureException(err)
 		svc.Logger.Error(err)

--- a/cmd/payment-reconciliation/main.go
+++ b/cmd/payment-reconciliation/main.go
@@ -17,6 +17,9 @@ import (
 )
 
 // script to reconcile pending payments between the backup node and the database
+// normally, this reconciliation should happen through rabbitmq but there are
+// cases where it doesn't happen and in that case this script can be run as a a
+// cron job as a redundant reconcilation mechanism.
 func main() {
 
 	c := &service.Config{}

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -121,7 +121,10 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 
 	//start payment checking loop
 	go func() {
-		err = suite.service.CheckAllPendingOutgoingPayments(context.Background())
+		ctx := context.Background()
+		pending, err := suite.service.GetAllPendingPayments(ctx)
+		assert.NoError(suite.T(), err)
+		err = suite.service.CheckPendingOutgoingPayments(ctx, pending)
 		assert.NoError(suite.T(), err)
 	}()
 	//wait a bit for routine to start
@@ -194,7 +197,10 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	assert.Equal(suite.T(), common.InvoiceStateInitialized, inv.State)
 	//start payment checking loop
 	go func() {
-		err = suite.service.CheckAllPendingOutgoingPayments(context.Background())
+		ctx := context.Background()
+		pending, err := suite.service.GetAllPendingPayments(ctx)
+		assert.NoError(suite.T(), err)
+		err = suite.service.CheckPendingOutgoingPayments(ctx, pending)
 		assert.NoError(suite.T(), err)
 	}()
 	//wait a bit for routine to start
@@ -273,7 +279,10 @@ func (suite *HodlInvoiceSuite) TestNegativeBalanceWithHodl() {
 
 	//start payment checking loop
 	go func() {
-		err = suite.service.CheckAllPendingOutgoingPayments(context.Background())
+		ctx := context.Background()
+		pending, err := suite.service.GetAllPendingPayments(ctx)
+		assert.NoError(suite.T(), err)
+		err = suite.service.CheckPendingOutgoingPayments(ctx, pending)
 		assert.NoError(suite.T(), err)
 	}()
 	//wait a bit for routine to start

--- a/lib/service/background_routines.go
+++ b/lib/service/background_routines.go
@@ -31,6 +31,7 @@ func (svc *LndhubService) StartPendingPaymentRoutine(ctx context.Context) (err e
 		if err != nil {
 			return err
 		}
+		svc.Logger.Infof("Found %d pending payments", len(pending))
 		return svc.CheckPendingOutgoingPayments(ctx, pending)
 	}
 }

--- a/lib/service/background_routines.go
+++ b/lib/service/background_routines.go
@@ -27,6 +27,10 @@ func (svc *LndhubService) StartPendingPaymentRoutine(ctx context.Context) (err e
 	if svc.RabbitMQClient != nil {
 		return svc.RabbitMQClient.FinalizeInitializedPayments(ctx, svc)
 	} else {
-		return svc.CheckAllPendingOutgoingPayments(ctx)
+		pending, err := svc.GetAllPendingPayments(ctx)
+		if err != nil {
+			return err
+		}
+		return svc.CheckPendingOutgoingPayments(ctx, pending)
 	}
 }

--- a/lib/service/checkpayments.go
+++ b/lib/service/checkpayments.go
@@ -7,12 +7,25 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/getAlby/lndhub.go/db/models"
 	"github.com/getsentry/sentry-go"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 )
+
+func (svc *LndhubService) GetPendingPaymentsUntil(ctx context.Context, ts time.Time) ([]models.Invoice, error) {
+	payments := []models.Invoice{}
+	err := svc.DB.NewSelect().
+		Model(&payments).
+		Where("state = 'initialized'").
+		Where("type = 'outgoing'").
+		Where("r_hash != ''").
+		Where("created_at >= (now() - interval '2 weeks') ").
+		Scan(ctx)
+	return payments, err
+}
 
 func (svc *LndhubService) GetAllPendingPayments(ctx context.Context) ([]models.Invoice, error) {
 	payments := []models.Invoice{}

--- a/lib/service/checkpayments.go
+++ b/lib/service/checkpayments.go
@@ -23,6 +23,7 @@ func (svc *LndhubService) GetPendingPaymentsUntil(ctx context.Context, ts time.T
 		Where("type = 'outgoing'").
 		Where("r_hash != ''").
 		Where("created_at >= (now() - interval '2 weeks') ").
+		Where("created_at < ? ", ts).
 		Scan(ctx)
 	return payments, err
 }

--- a/lib/service/checkpayments.go
+++ b/lib/service/checkpayments.go
@@ -34,7 +34,6 @@ func (svc *LndhubService) GetAllPendingPayments(ctx context.Context) ([]models.I
 	return payments, err
 }
 func (svc *LndhubService) CheckPendingOutgoingPayments(ctx context.Context, pendingPayments []models.Invoice) (err error) {
-	svc.Logger.Infof("Found %d pending payments", len(pendingPayments))
 	//call trackoutgoingpaymentstatus for each one
 	var wg sync.WaitGroup
 	for _, inv := range pendingPayments {

--- a/lib/service/checkpayments.go
+++ b/lib/service/checkpayments.go
@@ -19,12 +19,7 @@ func (svc *LndhubService) GetAllPendingPayments(ctx context.Context) ([]models.I
 	err := svc.DB.NewSelect().Model(&payments).Where("state = 'initialized'").Where("type = 'outgoing'").Where("r_hash != ''").Where("created_at >= (now() - interval '2 weeks') ").Scan(ctx)
 	return payments, err
 }
-func (svc *LndhubService) CheckAllPendingOutgoingPayments(ctx context.Context) (err error) {
-	pendingPayments, err := svc.GetAllPendingPayments(ctx)
-	if err != nil {
-		return err
-	}
-
+func (svc *LndhubService) CheckPendingOutgoingPayments(ctx context.Context, pendingPayments []models.Invoice) (err error) {
 	svc.Logger.Infof("Found %d pending payments", len(pendingPayments))
 	//call trackoutgoingpaymentstatus for each one
 	var wg sync.WaitGroup


### PR DESCRIPTION
Partial fix for #445  (still need deployment)
Since there still seem to be payments that are not being credited after a HODL invoice is settled, we must deploy a cron job to periodically check the pending payments in the database and track their status with LND.
Because we run this in a job and we want to avoid recent HODL payments, we only check the status of invoices older than 24h (and younger than 2 weeks). We also use a timeout to be sure this job doesn't keep on running.

The `cmd/payment-reconciliation` folder is already being built and added as a binary to the docker container. So to run this as a cron job, we just have to overwrite the containers default command.