### PR TITLE
 update simnet yaml files inside values

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -31,7 +31,7 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main' }}
       uses: fjogeleit/yaml-update-action@v0.7.0
       with:
-        valueFile: 'alby-simnet-deployment/values.yaml'
+        valueFile: 'alby-simnet-deployment/values/lndhub.yaml'
         propertyPath: 'lndhub.image.tag'
         value: ${{ steps.build.outputs.tags }}
         repository: getalby/alby-deployment


### PR DESCRIPTION
Merge must be coordinated with
getAlby/alby-deployment#230
which splits values.yaml file for simnet cluster into values/*.yaml for each deployment