### PR TITLE
Soft delete users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,7 @@
 	cp .env_example .env
 
 build:
-	CGO_ENABLED=0 go build -o lndhub
+	CGO_ENABLED=0 go build -o lndhub ./cmd/server
+
+test:
+	go test -p 1 -v -covermode=atomic -coverprofile=coverage.out -cover -coverpkg=./... ./...

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -153,8 +153,8 @@ func main() {
 	logMw := transport.CreateLoggingMiddleware(logger)
 	// strict rate limit for requests for sending payments
 	strictRateLimitMiddleware := transport.CreateRateLimitMiddleware(c.StrictRateLimit, c.BurstRateLimit)
-	secured := e.Group("", tokens.Middleware(c.JWTSecret), logMw)
-	securedWithStrictRateLimit := e.Group("", tokens.Middleware(c.JWTSecret), strictRateLimitMiddleware, logMw)
+	secured := e.Group("", tokens.Middleware(c.JWTSecret), svc.ValidateUserMiddleware(), logMw)
+	securedWithStrictRateLimit := e.Group("", tokens.Middleware(c.JWTSecret), svc.ValidateUserMiddleware(), strictRateLimitMiddleware, logMw)
 
 	transport.RegisterLegacyEndpoints(svc, e, secured, securedWithStrictRateLimit, strictRateLimitMiddleware, tokens.AdminTokenMiddleware(c.AdminToken), logMw)
 	transport.RegisterV2Endpoints(svc, e, secured, securedWithStrictRateLimit, strictRateLimitMiddleware, tokens.AdminTokenMiddleware(c.AdminToken), logMw)

--- a/controllers_v2/update.ctrl.go
+++ b/controllers_v2/update.ctrl.go
@@ -20,12 +20,14 @@ func NewUpdateUserController(svc *service.LndhubService) *UpdateUserController {
 type UpdateUserResponseBody struct {
 	Login       string `json:"login"`
 	Deactivated bool   `json:"deactivated"`
+	Deleted     bool   `json:"deleted"`
 	ID          int64  `json:"id"`
 }
 type UpdateUserRequestBody struct {
 	Login       *string `json:"login,omitempty"`
 	Password    *string `json:"password,omitempty"`
 	Deactivated *bool   `json:"deactivated,omitempty"`
+	Deleted     *bool   `json:"deleted,omitempty"`
 	ID          int64   `json:"id" validate:"required"`
 }
 
@@ -52,7 +54,7 @@ func (controller *UpdateUserController) UpdateUser(c echo.Context) error {
 		c.Logger().Errorf("Invalid update user request body error: %v", err)
 		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
-	user, err := controller.svc.UpdateUser(c.Request().Context(), body.ID, body.Login, body.Password, body.Deactivated)
+	user, err := controller.svc.UpdateUser(c.Request().Context(), body.ID, body.Login, body.Password, body.Deactivated, body.Deleted)
 	if err != nil {
 		c.Logger().Errorf("Failed to update user: %v", err)
 		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
@@ -61,6 +63,7 @@ func (controller *UpdateUserController) UpdateUser(c echo.Context) error {
 	var ResponseBody UpdateUserResponseBody
 	ResponseBody.Login = user.Login
 	ResponseBody.Deactivated = user.Deactivated
+	ResponseBody.Deleted = user.Deleted
 	ResponseBody.ID = user.ID
 
 	return c.JSON(http.StatusOK, &ResponseBody)

--- a/db/migrations/20240103130000_add_deleted_to_users.up.sql
+++ b/db/migrations/20240103130000_add_deleted_to_users.up.sql
@@ -1,0 +1,1 @@
+alter table users add column deleted boolean default false;

--- a/db/models/user.go
+++ b/db/models/user.go
@@ -19,6 +19,7 @@ type User struct {
 	Invoices    []*Invoice `bun:"rel:has-many,join:id=user_id"`
 	Accounts    []*Account `bun:"rel:has-many,join:id=user_id"`
 	Deactivated bool
+	Deleted     bool
 }
 
 func (u *User) BeforeAppendModel(ctx context.Context, query bun.Query) error {

--- a/integration_tests/deactivated_deleted_test.go
+++ b/integration_tests/deactivated_deleted_test.go
@@ -1,0 +1,101 @@
+package integration_tests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getAlby/lndhub.go/controllers"
+	"github.com/getAlby/lndhub.go/lib"
+	"github.com/getAlby/lndhub.go/lib/responses"
+	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/getAlby/lndhub.go/lib/tokens"
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type ValidateUserSuite struct {
+	TestSuite
+	Service                  *service.LndhubService
+	userLogin                ExpectedCreateUserResponseBody
+	userToken                string
+	mockLND                  *MockLND
+	invoiceUpdateSubCancelFn context.CancelFunc
+}
+
+func (suite *ValidateUserSuite) SetupSuite() {
+	mockLND := newDefaultMockLND()
+	svc, err := LndHubTestServiceInit(mockLND)
+	if err != nil {
+		log.Fatalf("Error initializing test service: %v", err)
+	}
+	users, userTokens, err := createUsers(svc, 1)
+	if err != nil {
+		log.Fatalf("Error creating test users %v", err)
+	}
+	suite.Service = svc
+	suite.mockLND = mockLND
+	e := echo.New()
+
+	e.HTTPErrorHandler = responses.HTTPErrorHandler
+	e.Validator = &lib.CustomValidator{Validator: validator.New()}
+	suite.echo = e
+	suite.echo.Use(tokens.Middleware([]byte(suite.Service.Config.JWTSecret)))
+	suite.echo.Use(svc.ValidateUserMiddleware())
+	suite.echo.GET("/gettxs", controllers.NewGetTXSController(suite.Service).GetTXS)
+	suite.echo.GET("/getuserinvoices", controllers.NewGetTXSController(svc).GetUserInvoices)
+	suite.echo.POST("/addinvoice", controllers.NewAddInvoiceController(suite.Service).AddInvoice)
+	suite.echo.POST("/payinvoice", controllers.NewPayInvoiceController(suite.Service).PayInvoice)
+
+	assert.Equal(suite.T(), 1, len(users))
+	suite.userLogin = users[0]
+	suite.userToken = userTokens[0]
+}
+
+func (suite *ValidateUserSuite) TearDownSuite() {
+}
+
+func (suite *ValidateUserSuite) TestDeletedUserValidation() {
+	_, err := suite.Service.DB.NewUpdate().Table("users").Set("deleted = ?", true).Where("login = ?", suite.userLogin.Login).Exec(context.TODO())
+	assert.NoError(suite.T(), err)
+	req := httptest.NewRequest(http.MethodGet, "/gettxs", nil)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
+	rec := httptest.NewRecorder()
+	suite.echo.ServeHTTP(rec, req)
+	assert.Equal(suite.T(), http.StatusUnauthorized, rec.Code)
+
+	_, err = suite.Service.DB.NewUpdate().Table("users").Set("deleted = ?", false).Where("login = ?", suite.userLogin.Login).Exec(context.TODO())
+	assert.NoError(suite.T(), err)
+	req = httptest.NewRequest(http.MethodGet, "/gettxs", nil)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
+	rec = httptest.NewRecorder()
+	suite.echo.ServeHTTP(rec, req)
+	assert.Equal(suite.T(), http.StatusOK, rec.Code)
+}
+
+func (suite *ValidateUserSuite) TestDeactivatedUserValidation() {
+	_, err := suite.Service.DB.NewUpdate().Table("users").Set("deactivated = ?, deleted = false", true).Where("login = ?", suite.userLogin.Login).Exec(context.TODO())
+	assert.NoError(suite.T(), err)
+	req := httptest.NewRequest(http.MethodGet, "/gettxs", nil)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
+	rec := httptest.NewRecorder()
+	suite.echo.ServeHTTP(rec, req)
+	assert.Equal(suite.T(), http.StatusUnauthorized, rec.Code)
+
+	_, err = suite.Service.DB.NewUpdate().Table("users").Set("deactivated = ?, deleted = false", false).Where("login = ?", suite.userLogin.Login).Exec(context.TODO())
+	assert.NoError(suite.T(), err)
+	req = httptest.NewRequest(http.MethodGet, "/gettxs", nil)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken))
+	rec = httptest.NewRecorder()
+	suite.echo.ServeHTTP(rec, req)
+	assert.Equal(suite.T(), http.StatusOK, rec.Code)
+}
+
+func TestValidateUserSuite(t *testing.T) {
+	suite.Run(t, new(ValidateUserSuite))
+}

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -47,7 +47,10 @@ const (
 )
 
 func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *service.LndhubService, err error) {
-	dbUri := "postgresql://user:password@localhost/lndhub?sslmode=disable"
+	dbUri, ok := os.LookupEnv("DATABASE_URI")
+	if !ok {
+		dbUri = "postgresql://user:password@localhost/lndhub?sslmode=disable"
+	}
 	c := &service.Config{
 		DatabaseUri:             dbUri,
 		DatabaseMaxConns:        1,

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -78,7 +78,7 @@ func (svc *LndhubService) CreateUser(ctx context.Context, login string, password
 	return user, err
 }
 
-func (svc *LndhubService) UpdateUser(ctx context.Context, userId int64, login *string, password *string, deactivated *bool) (user *models.User, err error) {
+func (svc *LndhubService) UpdateUser(ctx context.Context, userId int64, login *string, password *string, deactivated *bool, deleted *bool) (user *models.User, err error) {
 	user, err = svc.FindUser(ctx, userId)
 	if err != nil {
 		return nil, err
@@ -98,6 +98,14 @@ func (svc *LndhubService) UpdateUser(ctx context.Context, userId int64, login *s
 	}
 	if deactivated != nil {
 		user.Deactivated = *deactivated
+	}
+	// if a user gets deleted we mark it as deactivated and deleted
+	// un-deleting it is not supported currently
+	if deleted != nil {
+		if *deleted == true {
+			user.Deactivated = true
+			user.Deleted = true
+		}
 	}
 	_, err = svc.DB.NewUpdate().Model(user).WherePK().Exec(ctx)
 	if err != nil {

--- a/lib/tokens/jwt.go
+++ b/lib/tokens/jwt.go
@@ -15,13 +15,13 @@ import (
 )
 
 type jwtCustomClaims struct {
-	ID                 int64 `json:"id"`
-	IsRefresh          bool  `json:"isRefresh"`
-	MaxSendVolume      int64 `json:"maxSendVolume"`
-	MaxSendAmount      int64 `json:"maxSendAmount"`
-	MaxReceiveVolume   int64 `json:"maxReceiveVolume"`
-	MaxReceiveAmount   int64 `json:"maxReceiveAmount"`
-	MaxAccountBalance  int64 `json:"maxAccountBalance"`
+	ID                int64 `json:"id"`
+	IsRefresh         bool  `json:"isRefresh"`
+	MaxSendVolume     int64 `json:"maxSendVolume"`
+	MaxSendAmount     int64 `json:"maxSendAmount"`
+	MaxReceiveVolume  int64 `json:"maxReceiveVolume"`
+	MaxReceiveAmount  int64 `json:"maxReceiveAmount"`
+	MaxAccountBalance int64 `json:"maxAccountBalance"`
 	jwt.StandardClaims
 }
 


### PR DESCRIPTION
This allows users to be marked as deleted.
An additional middleware checks if a user is deleted or deactivated and rejects
requests for those as StatusUnauthorized.

note: the middelware adds an additional DB query to load the user.

[closes #468]