### PR TITLE
Return correct Amount and Fee on the payment responses

### DIFF
--- a/controllers_v2/keysend.ctrl.go
+++ b/controllers_v2/keysend.ctrl.go
@@ -247,8 +247,8 @@ func (controller *KeySendController) SingleKeySend(ctx context.Context, reqBody 
 	}
 
 	responseBody := &KeySendResponseBody{
-		Amount:          sendPaymentResponse.PaymentRoute.TotalAmt,
-		Fee:             sendPaymentResponse.PaymentRoute.TotalFees,
+		Amount:          invoice.Amount,
+		Fee:             invoice.Fee,
 		CustomRecords:   customRecords,
 		Description:     reqBody.Memo,
 		Destination:     reqBody.Destination,

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -129,8 +129,8 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	}
 	responseBody := &PayInvoiceResponseBody{
 		PaymentRequest:  paymentRequest,
-		Amount:          sendPaymentResponse.PaymentRoute.TotalAmt,
-		Fee:             sendPaymentResponse.PaymentRoute.TotalFees,
+		Amount:          invoice.Amount,
+		Fee:             invoice.Fee,
 		Description:     invoice.Memo,
 		DescriptionHash: invoice.DescriptionHash,
 		Destination:     invoice.DestinationPubkeyHex,


### PR DESCRIPTION
So far we have returned the total amount (which includes the fee) and the fee. This information was taken from the payment route response now we directly return it from the invoice data. This is consistent with the other transaction responses