### PR TITLE
chore: allow 0 limits for send/receive amount/volume

### DIFF
--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -204,7 +204,7 @@ func (suite *PaymentTestSuite) TestIncomingExceededChecks() {
 	assert.Equal(suite.T(), responses.BalanceExceededError.Message, resp.Message)
 
 	//change the config back and add sats, it should work now
-	suite.service.Config.MaxAccountBalance = 0
+	suite.service.Config.MaxAccountBalance = -1
 	invoiceResponse = suite.createAddInvoiceReq(aliceFundingSats, "integration test internal payment alice", suite.aliceToken)
 	err = suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
 	assert.NoError(suite.T(), err)

--- a/integration_tests/internal_payment_test.go
+++ b/integration_tests/internal_payment_test.go
@@ -228,7 +228,7 @@ func (suite *PaymentTestSuite) TestIncomingExceededChecks() {
 	assert.Equal(suite.T(), responses.TooMuchVolumeError.Message, resp.Message)
 
 	//change the config back, it should work now
-	suite.service.Config.MaxReceiveVolume = 0
+	suite.service.Config.MaxReceiveVolume = -1
 	suite.service.Config.MaxVolumePeriod = 0
 	invoiceResponse = suite.createAddInvoiceReq(aliceFundingSats, "integration test internal payment alice", suite.aliceToken)
 	err = suite.mlnd.mockPaidInvoice(invoiceResponse, 0, false, nil)
@@ -310,8 +310,8 @@ func (suite *PaymentTestSuite) TestOutgoingExceededChecks() {
 	assert.Equal(suite.T(), responses.TooMuchVolumeError.Message, resp.Message)
 
 	//change the config back
-	suite.service.Config.MaxSendAmount = 0
-	suite.service.Config.MaxSendVolume = 0
+	suite.service.Config.MaxSendAmount = -1
+	suite.service.Config.MaxSendVolume = -1
 	suite.service.Config.MaxVolumePeriod = 0
 }
 

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -49,7 +49,7 @@ const (
 func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *service.LndhubService, err error) {
 	dbUri, ok := os.LookupEnv("DATABASE_URI")
 	if !ok {
-		dbUri = "postgresql://im-adithya:password@localhost:5432/lndhub?sslmode=disable"
+		dbUri = "postgresql://user:password@localhost/lndhub?sslmode=disable"
 	}
 	dc := &service.Config{}
 	fmt.Println("dc.MaxSendAmount")

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -51,9 +51,6 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 	if !ok {
 		dbUri = "postgresql://user:password@localhost/lndhub?sslmode=disable"
 	}
-	dc := &service.Config{}
-	fmt.Println("dc.MaxSendAmount")
-	fmt.Println(dc.MaxSendAmount)
 	c := &service.Config{
 		DatabaseUri:             dbUri,
 		DatabaseMaxConns:        1,

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -49,8 +49,11 @@ const (
 func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *service.LndhubService, err error) {
 	dbUri, ok := os.LookupEnv("DATABASE_URI")
 	if !ok {
-		dbUri = "postgresql://user:password@localhost/lndhub?sslmode=disable"
+		dbUri = "postgresql://im-adithya:password@localhost:5432/lndhub?sslmode=disable"
 	}
+	dc := &service.Config{}
+	fmt.Println("dc.MaxSendAmount")
+	fmt.Println(dc.MaxSendAmount)
 	c := &service.Config{
 		DatabaseUri:             dbUri,
 		DatabaseMaxConns:        1,
@@ -64,6 +67,7 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 		MaxSendVolume:           -1,
 		MaxReceiveAmount:        -1,
 		MaxReceiveVolume:        -1,
+		MaxAccountBalance:       -1,
 	}
 
 	rabbitmqUri, ok := os.LookupEnv("RABBITMQ_URI")

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -60,6 +60,10 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 		JWTSecret:               []byte("SECRET"),
 		JWTAccessTokenExpiry:    3600,
 		JWTRefreshTokenExpiry:   3600,
+		MaxSendAmount:           -1,
+		MaxSendVolume:           -1,
+		MaxReceiveAmount:        -1,
+		MaxReceiveVolume:        -1,
 	}
 
 	rabbitmqUri, ok := os.LookupEnv("RABBITMQ_URI")

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	MinPasswordEntropy               int     `envconfig:"MIN_PASSWORD_ENTROPY" default:"0"`
 	MaxReceiveAmount                 int64   `envconfig:"MAX_RECEIVE_AMOUNT" default:"-1"`
 	MaxSendAmount                    int64   `envconfig:"MAX_SEND_AMOUNT" default:"-1"`
-	MaxAccountBalance                int64   `envconfig:"MAX_ACCOUNT_BALANCE" default:"0"`
+	MaxAccountBalance                int64   `envconfig:"MAX_ACCOUNT_BALANCE" default:"-1"`
 	MaxFeeAmount                     int64   `envconfig:"MAX_FEE_AMOUNT" default:"5000"`
 	MaxSendVolume                    int64   `envconfig:"MAX_SEND_VOLUME" default:"-1"`         //-1 means the volume check is disabled by default
 	MaxReceiveVolume                 int64   `envconfig:"MAX_RECEIVE_VOLUME" default:"-1"`      //-1 means the volume check is disabled by default

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -35,12 +35,12 @@ type Config struct {
 	NoServiceFeeUpToAmount           int     `envconfig:"NO_SERVICE_FEE_UP_TO_AMOUNT" default:"0"`
 	AllowAccountCreation             bool    `envconfig:"ALLOW_ACCOUNT_CREATION" default:"true"`
 	MinPasswordEntropy               int     `envconfig:"MIN_PASSWORD_ENTROPY" default:"0"`
-	MaxReceiveAmount                 int64   `envconfig:"MAX_RECEIVE_AMOUNT" default:"0"`
-	MaxSendAmount                    int64   `envconfig:"MAX_SEND_AMOUNT" default:"0"`
+	MaxReceiveAmount                 int64   `envconfig:"MAX_RECEIVE_AMOUNT" default:"-1"`
+	MaxSendAmount                    int64   `envconfig:"MAX_SEND_AMOUNT" default:"-1"`
 	MaxAccountBalance                int64   `envconfig:"MAX_ACCOUNT_BALANCE" default:"0"`
 	MaxFeeAmount                     int64   `envconfig:"MAX_FEE_AMOUNT" default:"5000"`
-	MaxSendVolume                    int64   `envconfig:"MAX_SEND_VOLUME" default:"0"`         //0 means the volume check is disabled by default
-	MaxReceiveVolume                 int64   `envconfig:"MAX_RECEIVE_VOLUME" default:"0"`      //0 means the volume check is disabled by default
+	MaxSendVolume                    int64   `envconfig:"MAX_SEND_VOLUME" default:"-1"`         //-1 means the volume check is disabled by default
+	MaxReceiveVolume                 int64   `envconfig:"MAX_RECEIVE_VOLUME" default:"-1"`      //-1 means the volume check is disabled by default
 	MaxVolumePeriod                  int64   `envconfig:"MAX_VOLUME_PERIOD" default:"2592000"` //in seconds, default 1 month
 	RabbitMQUri                      string  `envconfig:"RABBITMQ_URI"`
 	RabbitMQLndhubInvoiceExchange    string  `envconfig:"RABBITMQ_INVOICE_EXCHANGE" default:"lndhub_invoice"`

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -326,17 +326,17 @@ func (svc *LndhubService) GetLimits(c echo.Context) (limits *Limits) {
 		MaxReceiveAmount:  svc.Config.MaxReceiveAmount,
 		MaxAccountBalance: svc.Config.MaxAccountBalance,
 	}
-	if val, ok := c.Get("MaxSendVolume").(int64); ok && val >= -1 {
-		limits.MaxSendVolume = val
+	if val, ok := c.Get("MaxSendVolume").(*int64); ok && val != nil {
+		limits.MaxSendVolume = *val
 	}
-	if val, ok := c.Get("MaxSendAmount").(int64); ok && val >= -1 {
-		limits.MaxSendAmount = val
+	if val, ok := c.Get("MaxSendAmount").(*int64); ok && val != nil {
+		limits.MaxSendAmount = *val
 	}
-	if val, ok := c.Get("MaxReceiveVolume").(int64); ok && val >= -1 {
-		limits.MaxReceiveVolume = val
+	if val, ok := c.Get("MaxReceiveVolume").(*int64); ok && val != nil {
+		limits.MaxReceiveVolume = *val
 	}
-	if val, ok := c.Get("MaxReceiveAmount").(int64); ok && val >= -1 {
-		limits.MaxReceiveAmount = val
+	if val, ok := c.Get("MaxReceiveAmount").(*int64); ok && val != nil {
+		limits.MaxReceiveAmount = *val
 	}
 	if val, ok := c.Get("MaxAccountBalance").(int64); ok && val > 0 {
 		limits.MaxAccountBalance = val

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -221,7 +221,7 @@ func (svc *LndhubService) CheckIncomingPaymentAllowed(c echo.Context, amount, us
 		}
 	}
 
-	if limits.MaxAccountBalance > 0 {
+	if limits.MaxAccountBalance >= 0 {
 		currentBalance, err := svc.CurrentUserBalance(c.Request().Context(), userId)
 		if err != nil {
 			svc.Logger.Errorj(
@@ -338,8 +338,8 @@ func (svc *LndhubService) GetLimits(c echo.Context) (limits *Limits) {
 	if val, ok := c.Get("MaxReceiveAmount").(*int64); ok && val != nil {
 		limits.MaxReceiveAmount = *val
 	}
-	if val, ok := c.Get("MaxAccountBalance").(int64); ok && val > 0 {
-		limits.MaxAccountBalance = val
+	if val, ok := c.Get("MaxAccountBalance").(*int64); ok && val != nil {
+		limits.MaxAccountBalance = *val
 	}
 
 	return limits

--- a/lib/tokens/jwt.go
+++ b/lib/tokens/jwt.go
@@ -21,7 +21,7 @@ type jwtCustomClaims struct {
 	MaxSendAmount     *int64 `json:"maxSendAmount,omitempty"`
 	MaxReceiveVolume  *int64 `json:"maxReceiveVolume,omitempty"`
 	MaxReceiveAmount  *int64 `json:"maxReceiveAmount,omitempty"`
-	MaxAccountBalance int64  `json:"maxAccountBalance"`
+	MaxAccountBalance *int64 `json:"maxAccountBalance,omitempty"`
 	jwt.StandardClaims
 }
 

--- a/lib/tokens/jwt.go
+++ b/lib/tokens/jwt.go
@@ -15,13 +15,13 @@ import (
 )
 
 type jwtCustomClaims struct {
-	ID                int64 `json:"id"`
-	IsRefresh         bool  `json:"isRefresh"`
-	MaxSendVolume     int64 `json:"maxSendVolume"`
-	MaxSendAmount     int64 `json:"maxSendAmount"`
-	MaxReceiveVolume  int64 `json:"maxReceiveVolume"`
-	MaxReceiveAmount  int64 `json:"maxReceiveAmount"`
-	MaxAccountBalance int64 `json:"maxAccountBalance"`
+	ID                int64  `json:"id"`
+	IsRefresh         bool   `json:"isRefresh"`
+	MaxSendVolume     *int64 `json:"maxSendVolume,omitempty"`
+	MaxSendAmount     *int64 `json:"maxSendAmount,omitempty"`
+	MaxReceiveVolume  *int64 `json:"maxReceiveVolume,omitempty"`
+	MaxReceiveAmount  *int64 `json:"maxReceiveAmount,omitempty"`
+	MaxAccountBalance int64  `json:"maxAccountBalance"`
 	jwt.StandardClaims
 }
 


### PR DESCRIPTION
Post this, if we wish to remove the limit we use -1 (not 0)


And this is only for `MaxSendVolume`, `MaxSendAmount`, `MaxReceiveVolume`, `MaxReceiveAmount`
*Everything in limits except `MaxAccountBalance`