### PR TITLE
fix: increase rabbitmq reconnect backoff max time to 30min

### DIFF
--- a/rabbitmq/amqp.go
+++ b/rabbitmq/amqp.go
@@ -116,7 +116,7 @@ func (c *defaultAMQPCLient) reconnectionLoop() error {
 			exponentialBackoff := backoff.NewExponentialBackOff()
 
 			exponentialBackoff.MaxInterval = time.Second * 10
-			exponentialBackoff.MaxElapsedTime = time.Minute
+			exponentialBackoff.MaxElapsedTime = time.Minute * 30
 
 			c.reconFlag.Store(true)
 


### PR DESCRIPTION
currently it's 1 minute only